### PR TITLE
VIDSOL-294: update ci supporting develop branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,7 @@ permissions:
 on:
   push:
     branches:
+      - develop
       - main
 
   pull_request:

--- a/.github/workflows/publish-play-store.yml
+++ b/.github/workflows/publish-play-store.yml
@@ -3,7 +3,7 @@ name: Publish to Play Store
 on:
   push:
     branches:
-      - main
+      - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
#### What is this PR doing?
update ci supporting develop branch

#### How should this be manually tested?


#### What are the relevant tickets?

[VIDSOL-294](https://jira.vonage.com/browse/VIDSOL-294)


#### Justification for skipping ci, if applied?
