### PR TITLE
VIDSOL-398: simplify and cleanup landing screen

### DIFF
--- a/app/src/androidTest/java/com/vonage/android/screen/landing/LandingScreenTest.kt
+++ b/app/src/androidTest/java/com/vonage/android/screen/landing/LandingScreenTest.kt
@@ -42,7 +42,7 @@ class LandingScreenTest {
         compose.setContent {
             VonageVideoTheme {
                 LandingScreen(
-                    uiState = LandingScreenUiState(),
+                    uiState = LandingScreenUiState.Content(),
                     actions = NO_OP_JOIN_MEETING_ROOM_ACTIONS,
                 )
             }
@@ -67,7 +67,7 @@ class LandingScreenTest {
         compose.setContent {
             VonageVideoTheme {
                 LandingScreen(
-                    uiState = LandingScreenUiState(
+                    uiState = LandingScreenUiState.Content(
                         roomName = "hithere",
                     ),
                     actions = NO_OP_JOIN_MEETING_ROOM_ACTIONS,
@@ -96,7 +96,7 @@ class LandingScreenTest {
         compose.setContent {
             VonageVideoTheme {
                 LandingScreen(
-                    uiState = LandingScreenUiState(
+                    uiState = LandingScreenUiState.Content(
                         roomName = "hi@there",
                         isRoomNameWrong = true,
                     ),
@@ -119,7 +119,7 @@ class LandingScreenTest {
     }
 
     companion object {
-        val NO_OP_JOIN_MEETING_ROOM_ACTIONS = JoinMeetingRoomActions(
+        val NO_OP_JOIN_MEETING_ROOM_ACTIONS = LandingScreenActions(
             onJoinRoomClick = {},
             onCreateRoomClick = {},
             onRoomNameChange = {},

--- a/app/src/main/java/com/vonage/android/screen/landing/LandingScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/LandingScreen.kt
@@ -23,44 +23,51 @@ import com.vonage.android.screen.landing.components.LandingScreenHeader
 @Composable
 fun LandingScreen(
     uiState: LandingScreenUiState,
-    actions: JoinMeetingRoomActions,
+    actions: LandingScreenActions,
     modifier: Modifier = Modifier,
-    navigateToRoom: (JoinMeetingRoomRouteParams) -> Unit = {},
+    navigateToRoom: (LandingScreenRouteParams) -> Unit = {},
 ) {
     val context = LocalContext.current
     val errorMessage = stringResource(R.string.landing_room_generic_error_message)
 
-    LaunchedEffect(uiState.isError, uiState.isSuccess) {
-        if (uiState.isError) {
-            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+    when (uiState) {
+        is LandingScreenUiState.Content -> {
+            LaunchedEffect(uiState.isError) {
+                if (uiState.isError) {
+                    Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+                }
+            }
+
+            TwoPaneScaffold(
+                modifier = modifier.fillMaxSize(),
+                topBar = { TopBanner() },
+                firstPane = {
+                    LandingScreenHeader(
+                        modifier = Modifier
+                            .padding(VonageVideoTheme.dimens.paddingLarge)
+                            .widthIn(0.dp, MAX_PANE_WIDTH.dp),
+                    )
+                },
+                secondPane = {
+                    LandingScreenContent(
+                        modifier = Modifier
+                            .background(VonageVideoTheme.colors.surface, VonageVideoTheme.shapes.small)
+                            .padding(VonageVideoTheme.dimens.paddingLarge)
+                            .widthIn(0.dp, MAX_PANE_WIDTH.dp),
+                        roomName = uiState.roomName,
+                        isRoomNameWrong = uiState.isRoomNameWrong,
+                        actions = actions,
+                    )
+                }
+            )
         }
-        if (uiState.isSuccess) {
-            navigateToRoom(JoinMeetingRoomRouteParams(roomName = uiState.roomName))
+
+        is LandingScreenUiState.Success -> {
+            LaunchedEffect(uiState) {
+                navigateToRoom(LandingScreenRouteParams(roomName = uiState.roomName))
+            }
         }
     }
-
-    TwoPaneScaffold(
-        modifier = modifier.fillMaxSize(),
-        topBar = { TopBanner() },
-        firstPane = {
-            LandingScreenHeader(
-                modifier = Modifier
-                    .padding(VonageVideoTheme.dimens.paddingLarge)
-                    .widthIn(0.dp, MAX_PANE_WIDTH.dp),
-            )
-        },
-        secondPane = {
-            LandingScreenContent(
-                modifier = Modifier
-                    .background(VonageVideoTheme.colors.surface, VonageVideoTheme.shapes.small)
-                    .padding(VonageVideoTheme.dimens.paddingLarge)
-                    .widthIn(0.dp, MAX_PANE_WIDTH.dp),
-                roomName = uiState.roomName,
-                isRoomNameWrong = uiState.isRoomNameWrong,
-                actions = actions,
-            )
-        }
-    )
 }
 
 private const val MAX_PANE_WIDTH = 550
@@ -71,15 +78,11 @@ private const val MAX_PANE_WIDTH = 550
 internal fun LandingScreenPreview() {
     VonageVideoTheme {
         LandingScreen(
-            uiState = LandingScreenUiState(
+            uiState = LandingScreenUiState.Content(
                 roomName = "hithere",
                 isRoomNameWrong = false,
             ),
-            actions = JoinMeetingRoomActions(
-                onJoinRoomClick = {},
-                onCreateRoomClick = {},
-                onRoomNameChange = {},
-            ),
+            actions = LandingScreenActions(),
         )
     }
 }

--- a/app/src/main/java/com/vonage/android/screen/landing/LandingScreenRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/LandingScreenRoute.kt
@@ -13,16 +13,16 @@ import com.vonage.android.util.pip.pipEffect
 internal fun LandingScreenRoute(
     modifier: Modifier = Modifier,
     viewModel: LandingScreenViewModel = hiltViewModel(),
-    navigateToRoom: (JoinMeetingRoomRouteParams) -> Unit,
+    navigateToRoom: (LandingScreenRouteParams) -> Unit,
 ) {
     val pipModifier = pipEffect(shouldEnterPipMode = false)
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     val actions = remember {
-        JoinMeetingRoomActions(
+        LandingScreenActions(
             onJoinRoomClick = viewModel::joinRoom,
             onCreateRoomClick = viewModel::createRoom,
-            onRoomNameChange = viewModel::updateName
+            onRoomNameChange = viewModel::updateName,
         )
     }
 
@@ -45,12 +45,12 @@ object LandingScreenTestTags {
 }
 
 @Stable
-data class JoinMeetingRoomActions(
+data class LandingScreenActions(
     val onJoinRoomClick: (String) -> Unit = {},
     val onCreateRoomClick: () -> Unit = {},
     val onRoomNameChange: (String) -> Unit = {},
 )
 
-data class JoinMeetingRoomRouteParams(
+data class LandingScreenRouteParams(
     val roomName: String,
 )

--- a/app/src/main/java/com/vonage/android/screen/landing/LandingScreenViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/LandingScreenViewModel.kt
@@ -15,12 +15,12 @@ class LandingScreenViewModel @Inject constructor(
     private val roomNameGenerator: RoomNameGenerator,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(LandingScreenUiState())
+    private val _uiState = MutableStateFlow<LandingScreenUiState>(LandingScreenUiState.Content())
     val uiState: StateFlow<LandingScreenUiState> = _uiState.asStateFlow()
 
     fun updateName(roomName: String) {
         val roomNameError = roomName.isValidRoomName().not()
-        _uiState.value = LandingScreenUiState(
+        _uiState.value = LandingScreenUiState.Content(
             roomName = roomName,
             isRoomNameWrong = roomNameError,
         )
@@ -33,12 +33,11 @@ class LandingScreenViewModel @Inject constructor(
 
     fun joinRoom(roomName: String) {
         if (roomName.isValidRoomName()) {
-            _uiState.value = LandingScreenUiState(
+            _uiState.value = LandingScreenUiState.Success(
                 roomName = roomName,
-                isSuccess = true,
             )
         } else {
-            _uiState.value = LandingScreenUiState(
+            _uiState.value = LandingScreenUiState.Content(
                 roomName = roomName,
                 isRoomNameWrong = true,
             )
@@ -47,9 +46,14 @@ class LandingScreenViewModel @Inject constructor(
 }
 
 @Immutable
-data class LandingScreenUiState(
-    val roomName: String = "",
-    val isRoomNameWrong: Boolean = false,
-    val isError: Boolean = false,
-    val isSuccess: Boolean = false,
-)
+sealed interface LandingScreenUiState {
+    data class Content(
+        val roomName: String = "",
+        val isRoomNameWrong: Boolean = false,
+        val isError: Boolean = false,
+    ) : LandingScreenUiState
+
+    data class Success(
+        val roomName: String = "",
+    ) : LandingScreenUiState
+}

--- a/app/src/main/java/com/vonage/android/screen/landing/components/LandingRoomInput.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/components/LandingRoomInput.kt
@@ -17,7 +17,7 @@ import com.vonage.android.R
 import com.vonage.android.compose.components.VonageOutlinedButton
 import com.vonage.android.compose.components.VonageTextField
 import com.vonage.android.compose.theme.VonageVideoTheme
-import com.vonage.android.screen.landing.JoinMeetingRoomActions
+import com.vonage.android.screen.landing.LandingScreenActions
 import com.vonage.android.screen.landing.LandingScreenTestTags.JOIN_BUTTON_TAG
 import com.vonage.android.screen.landing.LandingScreenTestTags.ROOM_INPUT_ERROR_TAG
 import com.vonage.android.screen.landing.LandingScreenTestTags.ROOM_INPUT_TAG
@@ -25,10 +25,10 @@ import com.vonage.android.compose.modifier.clearFocusOnKeyboardDismiss
 import com.vonage.android.util.MAX_ROOM_NAME_LENGTH
 
 @Composable
-internal fun RoomInput(
+internal fun LandingRoomInput(
     roomName: String,
     isRoomNameWrong: Boolean,
-    actions: JoinMeetingRoomActions,
+    actions: LandingScreenActions,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -72,16 +72,16 @@ internal fun RoomInput(
 
 @PreviewLightDark
 @Composable
-internal fun RoomInputPreview() {
+internal fun LandingRoomInputPreview() {
     VonageVideoTheme {
         Surface(
             modifier = Modifier
                 .background(VonageVideoTheme.colors.background)
         ) {
-            RoomInput(
+            LandingRoomInput(
                 roomName = "room-name",
                 isRoomNameWrong = false,
-                actions = JoinMeetingRoomActions(),
+                actions = LandingScreenActions(),
             )
         }
     }

--- a/app/src/main/java/com/vonage/android/screen/landing/components/LandingScreenContent.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/components/LandingScreenContent.kt
@@ -1,27 +1,30 @@
 package com.vonage.android.screen.landing.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.vonage.android.R
 import com.vonage.android.compose.components.VonageButton
 import com.vonage.android.compose.icons.PlusIcon
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.screen.components.OrSeparator
-import com.vonage.android.screen.landing.JoinMeetingRoomActions
+import com.vonage.android.screen.landing.LandingScreenActions
 import com.vonage.android.screen.landing.LandingScreenTestTags.CREATE_ROOM_BUTTON_TAG
 
 @Composable
 internal fun LandingScreenContent(
     roomName: String,
     isRoomNameWrong: Boolean,
-    actions: JoinMeetingRoomActions,
+    actions: LandingScreenActions,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -46,10 +49,26 @@ internal fun LandingScreenContent(
             text = stringResource(R.string.landing_enter_room_name_title),
             style = VonageVideoTheme.typography.heading4,
         )
-        RoomInput(
+        LandingRoomInput(
             roomName = roomName,
             isRoomNameWrong = isRoomNameWrong,
             actions = actions,
         )
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun LandingScreenContentPreview() {
+    VonageVideoTheme {
+        Surface(
+            modifier = Modifier.background(VonageVideoTheme.colors.background)
+        ) {
+            LandingScreenContent(
+                roomName = "room-name",
+                isRoomNameWrong = false,
+                actions = LandingScreenActions(),
+            )
+        }
     }
 }

--- a/app/src/main/java/com/vonage/android/screen/landing/components/LandingScreenHeader.kt
+++ b/app/src/main/java/com/vonage/android/screen/landing/components/LandingScreenHeader.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
 import com.vonage.android.R
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.screen.landing.LandingScreenTestTags.SUBTITLE_TAG
@@ -81,5 +82,13 @@ internal fun LandingScreenHeader(
             color = VonageVideoTheme.colors.textTertiary,
             textAlign = TextAlign.Start,
         )
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun LandingScreenHeaderPreview() {
+    VonageVideoTheme {
+        LandingScreenHeader()
     }
 }

--- a/app/src/test/java/com/vonage/android/screen/landing/LandingScreenViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/landing/LandingScreenViewModelTest.kt
@@ -11,7 +11,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class JoinMeetingRoomViewModelTest {
+class LandingScreenViewModelTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
@@ -32,7 +32,7 @@ class JoinMeetingRoomViewModelTest {
         sut.updateName("validroomname")
         sut.uiState.test {
             assertEquals(
-                LandingScreenUiState(
+                LandingScreenUiState.Content(
                     roomName = "validroomname",
                     isRoomNameWrong = false,
                 ),
@@ -46,7 +46,7 @@ class JoinMeetingRoomViewModelTest {
         sut.updateName("room@name")
         sut.uiState.test {
             assertEquals(
-                LandingScreenUiState(
+                LandingScreenUiState.Content(
                     roomName = "room@name",
                     isRoomNameWrong = true,
                 ),
@@ -63,9 +63,8 @@ class JoinMeetingRoomViewModelTest {
 
         sut.uiState.test {
             assertEquals(
-                LandingScreenUiState(
+                LandingScreenUiState.Success(
                     roomName = "vonage-rocks",
-                    isSuccess = true,
                 ),
                 awaitItem()
             )
@@ -78,9 +77,23 @@ class JoinMeetingRoomViewModelTest {
             awaitItem() // initial state
             sut.joinRoom("validname")
             assertEquals(
-                LandingScreenUiState(
+                LandingScreenUiState.Success(
                     roomName = "validname",
-                    isSuccess = true,
+                ),
+                awaitItem()
+            )
+        }
+    }
+
+    @Test
+    fun `given viewmodel when join room fails then state is correct`() = runTest {
+        sut.uiState.test {
+            awaitItem() // initial state
+            sut.joinRoom("invalid name")
+            assertEquals(
+                LandingScreenUiState.Content(
+                    roomName = "invalid name",
+                    isRoomNameWrong = true,
                 ),
                 awaitItem()
             )


### PR DESCRIPTION
#### What is this PR doing?
- Fix a weird behavior with room name input when click on create room button
- simplify and cleanup landing screen
- missing renames to landingScreen preffix

#### How should this be manually tested?


#### What are the relevant tickets?

[VIDSOL-398](https://jira.vonage.com/browse/VIDSOL-398)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### Justification for skipping ci, if applied?
