### PR TITLE
VIDSOL-423: main branch protection

### DIFF
--- a/.github/workflows/check-base-branch.yml
+++ b/.github/workflows/check-base-branch.yml
@@ -12,13 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check base branch
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+          HEAD_BRANCH: ${{ github.head_ref }}
         run: |
-          BASE_BRANCH="${{ github.base_ref }}"
-          HEAD_BRANCH="${{ github.head_ref }}"
-          
-          echo "Base branch: $BASE_BRANCH"
-          echo "Head branch: $HEAD_BRANCH"
-          
           # Check if head branch starts with 'release-'
           if [[ "$HEAD_BRANCH" == release-* ]]; then
             echo "Release branch detected: $HEAD_BRANCH"

--- a/.github/workflows/check-base-branch.yml
+++ b/.github/workflows/check-base-branch.yml
@@ -1,0 +1,43 @@
+name: check-pull-request-base-branch
+
+on:
+  pull_request:
+    types: [edited, opened]
+
+permissions:
+  contents: read
+
+jobs:
+  check-base-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check base branch
+        run: |
+          BASE_BRANCH="${{ github.base_ref }}"
+          HEAD_BRANCH="${{ github.head_ref }}"
+          
+          echo "Base branch: $BASE_BRANCH"
+          echo "Head branch: $HEAD_BRANCH"
+          
+          # Check if head branch starts with 'release-'
+          if [[ "$HEAD_BRANCH" == release-* ]]; then
+            echo "Release branch detected: $HEAD_BRANCH"
+            if [[ "$BASE_BRANCH" == "main" ]]; then
+              echo "Release branch targeting main - VALID"
+              exit 0
+            else
+              echo "Release branches must target 'main', but found '$BASE_BRANCH'"
+              exit 1
+            fi
+          else
+            # For non-release branches, base must be develop
+            if [[ "$BASE_BRANCH" == "develop" ]]; then
+              echo "Non-release branch targeting develop - VALID"
+              exit 0
+            else
+              echo "Non-release branches must target 'develop', but found '$BASE_BRANCH'"
+              echo "Note: Only branches starting with 'release-' can target 'main'"
+              exit 1
+            fi
+          fi
+        shell: bash

--- a/.github/workflows/check-base-branch.yml
+++ b/.github/workflows/check-base-branch.yml
@@ -2,13 +2,13 @@ name: check-pull-request-base-branch
 
 on:
   pull_request:
-    types: [edited, opened]
+    types: [edited, opened, reopened, synchronize]
 
 permissions:
   contents: read
 
 jobs:
-  check-base-branch:
+  validate-base-branch:
     runs-on: ubuntu-latest
     steps:
       - name: Check base branch

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -2,7 +2,7 @@ name: check-pull-request-title
 
 on:
   pull_request:
-    types: [edited, opened]
+    types: [edited, opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
#### What is this PR doing?
Protect `main` branch against merges by mistake.
Rules:
- allow merges to `main` branch only for branches starting with `release-`
- allow merges to `develop` by default

#### How should this be manually tested?


#### What are the relevant tickets?

[VIDSOL-423](https://jira.vonage.com/browse/VIDSOL-423)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### Justification for skipping ci, if applied?
