### PR TITLE
VIDSOL-414: screen sharing overlay indicator

### DIFF
--- a/vonage-feature-screensharing/build.gradle.kts
+++ b/vonage-feature-screensharing/build.gradle.kts
@@ -28,6 +28,10 @@ android {
         buildConfig = true
     }
 
+    testOptions {
+        unitTests { isReturnDefaultValues = true }
+    }
+
     flavorDimensions += "screensharing"
     productFlavors {
         create("enabled") {

--- a/vonage-feature-screensharing/src/disabled/java/com/vonage/android/screensharing/DisabledScreenSharing.kt
+++ b/vonage-feature-screensharing/src/disabled/java/com/vonage/android/screensharing/DisabledScreenSharing.kt
@@ -18,6 +18,14 @@ class DisabledScreenSharing : VonageScreenSharing {
     override fun stopSharingScreen() {
     }
 
+    override fun canDrawOverlays(): Boolean = false
+
+    override fun showOverlay() {
+    }
+
+    override fun hideOverlay() {
+    }
+
     override fun createNotificationChannel(manager: NotificationManager) {
     }
 }

--- a/vonage-feature-screensharing/src/enabled/AndroidManifest.xml
+++ b/vonage-feature-screensharing/src/enabled/AndroidManifest.xml
@@ -2,10 +2,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
     <application>
         <service
                 android:name=".service.ScreenSharingService"
                 android:exported="false"
                 android:foregroundServiceType="mediaProjection" />
+        <service
+                android:name=".service.ScreenSharingOverlayService"
+                android:exported="false" />
     </application>
 </manifest>

--- a/vonage-feature-screensharing/src/enabled/java/com/vonage/android/screensharing/service/ScreenSharingOverlayService.kt
+++ b/vonage-feature-screensharing/src/enabled/java/com/vonage/android/screensharing/service/ScreenSharingOverlayService.kt
@@ -1,0 +1,101 @@
+package com.vonage.android.screensharing.service
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.os.Build
+import android.os.IBinder
+import android.view.View
+import android.view.WindowManager
+import androidx.core.graphics.toColorInt
+
+/**
+ * Service that draws a colored border overlay on the screen while
+ * screen sharing is active, to remind the user that the screen is
+ * being captured.
+ */
+class ScreenSharingOverlayService : Service() {
+
+    private var overlayView: View? = null
+    private var windowManager: WindowManager? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
+        showOverlay()
+    }
+
+    override fun onDestroy() {
+        removeOverlay()
+        super.onDestroy()
+    }
+
+    private fun showOverlay() {
+        val borderWidth = BORDER_WIDTH_PX
+
+        overlayView = object : View(this) {
+            private val paint = Paint().apply {
+                color = BORDER_COLOR
+                style = Paint.Style.STROKE
+                strokeWidth = borderWidth
+            }
+
+            override fun onDraw(canvas: Canvas) {
+                super.onDraw(canvas)
+                val half = borderWidth / 2f
+                canvas.drawRect(
+                    half,
+                    half,
+                    width - half,
+                    height - half,
+                    paint,
+                )
+            }
+        }.apply {
+            setBackgroundColor(Color.TRANSPARENT)
+        }
+
+        val layoutType = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+        } else {
+            @Suppress("DEPRECATION")
+            WindowManager.LayoutParams.TYPE_PHONE
+        }
+
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.MATCH_PARENT,
+            layoutType,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+            PixelFormat.TRANSLUCENT,
+        )
+
+        windowManager?.addView(overlayView, params)
+    }
+
+    private fun removeOverlay() {
+        overlayView?.let { view ->
+            windowManager?.removeView(view)
+            overlayView = null
+        }
+    }
+
+    companion object {
+        /** Border thickness in pixels. */
+        private const val BORDER_WIDTH_PX = 8f
+
+        /** Border colour — a vivid red matching common screen-share indicators. */
+        private val BORDER_COLOR = "#00FF00".toColorInt()
+
+        fun intent(context: Context): Intent =
+            Intent(context, ScreenSharingOverlayService::class.java)
+    }
+}

--- a/vonage-feature-screensharing/src/enabled/java/com/vonage/android/screensharing/service/ScreenSharingOverlayService.kt
+++ b/vonage-feature-screensharing/src/enabled/java/com/vonage/android/screensharing/service/ScreenSharingOverlayService.kt
@@ -25,6 +25,9 @@ class ScreenSharingOverlayService : Service() {
 
     override fun onBind(intent: Intent?): IBinder? = null
 
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
+        START_NOT_STICKY
+
     override fun onCreate() {
         super.onCreate()
         windowManager = getSystemService(WINDOW_SERVICE) as WindowManager
@@ -73,8 +76,8 @@ class ScreenSharingOverlayService : Service() {
             WindowManager.LayoutParams.MATCH_PARENT,
             layoutType,
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-                or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
-                or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                    or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+                    or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
             PixelFormat.TRANSLUCENT,
         )
 
@@ -89,10 +92,7 @@ class ScreenSharingOverlayService : Service() {
     }
 
     companion object {
-        /** Border thickness in pixels. */
         private const val BORDER_WIDTH_PX = 8f
-
-        /** Border colour — a vivid red matching common screen-share indicators. */
         private val BORDER_COLOR = "#00FF00".toColorInt()
 
         fun intent(context: Context): Intent =

--- a/vonage-feature-screensharing/src/main/java/com/vonage/android/screensharing/VonageScreenSharing.kt
+++ b/vonage-feature-screensharing/src/main/java/com/vonage/android/screensharing/VonageScreenSharing.kt
@@ -30,6 +30,23 @@ interface VonageScreenSharing {
     fun stopSharingScreen()
 
     /**
+     * Returns `true` when the app has the `SYSTEM_ALERT_WINDOW` permission
+     * needed to render the screen-sharing border overlay.
+     */
+    fun canDrawOverlays(): Boolean
+
+    /**
+     * Shows a coloured border overlay to remind the user that screen sharing
+     * is in progress. Requires [canDrawOverlays] to return `true`.
+     */
+    fun showOverlay()
+
+    /**
+     * Hides the screen-sharing border overlay.
+     */
+    fun hideOverlay()
+
+    /**
      * Creates a notification channel required for screen sharing foreground service.
      *
      * @param manager [NotificationManager] used to register the channel.


### PR DESCRIPTION
#### What is this PR doing?
Show a border overlay while screen sharing

<img width="800" alt="image" src="https://github.com/user-attachments/assets/91dac289-567b-4278-9c3e-01d4fb37cda8" />

#### How should this be manually tested?


#### What are the relevant tickets?

[VIDSOL-414](https://jira.vonage.com/browse/VIDSOL-414)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### Justification for skipping ci, if applied?
