### PR TITLE
VIDSOL-796: add custom background image upload to video effects

### DIFF
--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
@@ -1,5 +1,6 @@
 package com.vonage.android.screen.waiting
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
@@ -12,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.screen.components.permissions.CallPermissionHandler
 import com.vonage.android.util.pip.pipEffect
@@ -41,6 +43,8 @@ fun WaitingRoomRoute(
             onJoinRoom = { userName -> viewModel.joinRoom(userName) },
             onCameraSwitch = viewModel::onCameraSwitch,
             onApplyVideoEffect = viewModel::applyVideoEffect,
+            onAddBackground = viewModel::addBackground,
+            onDeleteBackground = viewModel::deleteBackground,
             onBack = {
                 viewModel.onStop()
                 onBack()
@@ -94,6 +98,8 @@ data class WaitingRoomActions(
     val onCameraToggle: () -> Unit = {},
     val onOpenVideoEffects: () -> Unit = {},
     val onApplyVideoEffect: (VideoEffect) -> Unit = {},
+    val onAddBackground: (Uri) -> Unit = {},
+    val onDeleteBackground: (VideoBackgroundItem) -> Unit = {},
     val onCameraSwitch: () -> Unit = {},
     val onBack: () -> Unit = {},
 )

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
@@ -152,13 +152,25 @@ fun WaitingRoomScreen(
             onDismissRequest = { showVideoEffects = false },
             sheetState = videoEffectsSheetState,
         ) {
+            // Reset the local selection if the active background was deleted while the sheet is open.
+            LaunchedEffect(uiState.backgrounds) {
+                val current = selectedEffect
+                if (current is VideoEffect.BackgroundImage &&
+                    uiState.backgrounds.none { it.id == current.id }
+                ) {
+                    selectedEffect = VideoEffect.None
+                }
+            }
             VideoEffectsScreen(
                 backgrounds = uiState.backgrounds,
                 selectedEffect = selectedEffect,
+                canAddBackground = uiState.canAddBackground,
                 onEffectSelect = { effect ->
                     selectedEffect = effect
                     actions.onApplyVideoEffect(effect)
                 },
+                onAddBackground = actions.onAddBackground,
+                onDeleteBackground = actions.onDeleteBackground,
             )
         }
     }

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
@@ -153,9 +153,12 @@ fun WaitingRoomScreen(
             sheetState = videoEffectsSheetState,
         ) {
             // Reset the local selection if the active background was deleted while the sheet is open.
+            // Guard with isNotEmpty() so the effect doesn't fire while the list is still
+            // loading (empty initial state would otherwise clear any active selection).
             LaunchedEffect(uiState.backgrounds) {
                 val current = selectedEffect
                 if (current is VideoEffect.BackgroundImage &&
+                    uiState.backgrounds.isNotEmpty() &&
                     uiState.backgrounds.none { it.id == current.id }
                 ) {
                     selectedEffect = VideoEffect.None

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -1,13 +1,15 @@
 package com.vonage.android.screen.waiting
 
 import android.content.Context
+import android.net.Uri
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vonage.android.config.GetConfig
-import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.fx.data.BackgroundEffectsRepository
+import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.fx.ui.VideoBackgroundItem
+import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.settings.CallSettingsHolder
 import com.vonage.android.data.UserRepository
 import com.vonage.android.kotlin.VonageVideoClient
@@ -24,6 +26,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +38,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @HiltViewModel(assistedFactory = WaitingRoomViewModelFactory::class)
 class WaitingRoomViewModel @AssistedInject constructor(
@@ -55,14 +59,10 @@ class WaitingRoomViewModel @AssistedInject constructor(
         initialValue = WaitingRoomUiState(roomName = roomName),
     )
 
+    private val userBackgroundRepository = UserBackgroundRepository(appContext)
+
     init {
-        viewModelScope.launch(Dispatchers.IO) {
-            runCatching {
-                val repository = BackgroundEffectsRepository(appContext)
-                repository.getBackgrounds(callSettingsHolder.captureResolution.value)
-            }.getOrElse { persistentListOf() }
-                .also { backgrounds -> _uiState.update { it.copy(backgrounds = backgrounds) } }
-        }
+        viewModelScope.launch(Dispatchers.IO) { refreshBackgrounds() }
     }
 
     fun init(context: Context) {
@@ -113,6 +113,32 @@ class WaitingRoomViewModel @AssistedInject constructor(
         currentPublisher()?.applyVideoEffect(effect)
     }
 
+    /**
+     * Saves the image at [uri] to persistent storage and refreshes the backgrounds list.
+     * IO is performed internally on [Dispatchers.IO].
+     */
+    fun addBackground(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            userBackgroundRepository.saveBackground(uri, callSettingsHolder.captureResolution.value)
+            refreshBackgrounds()
+        }
+    }
+
+    /**
+     * Deletes the user-uploaded background identified by [item]. If the deleted background is
+     * currently active on the preview publisher, the effect is reset to [VideoEffect.None].
+     */
+    fun deleteBackground(item: VideoBackgroundItem) {
+        viewModelScope.launch(Dispatchers.IO) {
+            userBackgroundRepository.deleteBackground(item.id)
+            val currentEffect = _uiState.value.publisher?.videoEffect?.value
+            if (currentEffect is VideoEffect.BackgroundImage && currentEffect.id == item.id) {
+                withContext(Dispatchers.Main) { applyVideoEffect(VideoEffect.None) }
+            }
+            refreshBackgrounds()
+        }
+    }
+
     fun joinRoom(userName: String) {
         viewModelScope.launch {
             val sanitizedUserName = userName.sanitizeUserName()
@@ -149,6 +175,27 @@ class WaitingRoomViewModel @AssistedInject constructor(
         publisherSetupJob?.cancel()
         currentPublisher()?.clean()
         videoClient.destroyPublisher()
+    }
+
+    /**
+     * Merges built-in and user-uploaded backgrounds then updates the UI state.
+     * Must be called from [Dispatchers.IO].
+     */
+    private suspend fun refreshBackgrounds() {
+        val resolution = callSettingsHolder.captureResolution.value
+        val builtIn = runCatching {
+            BackgroundEffectsRepository(appContext).getBackgrounds(resolution)
+        }.getOrElse { persistentListOf() }
+        val user = runCatching {
+            userBackgroundRepository.getUserBackgrounds(resolution)
+        }.getOrElse { persistentListOf() }
+        val canAdd = user.size < UserBackgroundRepository.MAX_USER_BACKGROUNDS
+        _uiState.update {
+            it.copy(
+                backgrounds = (builtIn + user).toImmutableList(),
+                canAddBackground = canAdd,
+            )
+        }
     }
 
     private fun observeBuildTimeSettings(context: Context) {
@@ -237,5 +284,6 @@ data class WaitingRoomUiState(
     val allowCameraControl: Boolean = true,
     val audioDevicesState: AudioDevicesState? = null,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
+    /** Whether the "Add image" tile should be shown in the effects sheet. */
+    val canAddBackground: Boolean = true,
 )
-

--- a/vonage-feature-video-effects/build.gradle.kts
+++ b/vonage-feature-video-effects/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.opentok.android.sdk)
     enabledImplementation(libs.opentok.android.video.transformers)
+    enabledImplementation(libs.androidx.activity.compose)
 
     testImplementation(libs.junit.junit)
     testImplementation(libs.mockk)

--- a/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
+++ b/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
@@ -22,9 +22,6 @@ class UserBackgroundRepository(@Suppress("UNUSED_PARAMETER") context: Context) {
     @Suppress("FunctionOnlyReturningConstant")
     fun deleteBackground(id: String): Boolean = false
 
-    @Suppress("FunctionOnlyReturningConstant")
-    fun getCount(): Int = 0
-
     companion object {
         const val MAX_USER_BACKGROUNDS = 10
     }

--- a/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
+++ b/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
@@ -1,0 +1,31 @@
+package com.vonage.android.fx.data
+
+import android.content.Context
+import android.net.Uri
+import com.vonage.android.fx.ui.VideoBackgroundItem
+import com.vonage.android.kotlin.model.CaptureResolution
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+/**
+ * No-op stub for the disabled video effects flavor.
+ */
+@Suppress("UnusedParameter")
+class UserBackgroundRepository(@Suppress("UNUSED_PARAMETER") context: Context) {
+
+    fun getUserBackgrounds(captureResolution: CaptureResolution? = null): ImmutableList<VideoBackgroundItem> =
+        persistentListOf()
+
+    @Suppress("FunctionOnlyReturningConstant")
+    fun saveBackground(uri: Uri, captureResolution: CaptureResolution? = null): VideoBackgroundItem? = null
+
+    @Suppress("FunctionOnlyReturningConstant")
+    fun deleteBackground(id: String): Boolean = false
+
+    @Suppress("FunctionOnlyReturningConstant")
+    fun getCount(): Int = 0
+
+    companion object {
+        const val MAX_USER_BACKGROUNDS = 10
+    }
+}

--- a/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
+++ b/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
@@ -1,5 +1,6 @@
 package com.vonage.android.fx.ui
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.vonage.android.kotlin.model.VideoEffect
@@ -10,7 +11,9 @@ import kotlinx.collections.immutable.ImmutableList
 fun VideoEffectsScreen(
     backgrounds: ImmutableList<VideoBackgroundItem>,
     selectedEffect: VideoEffect,
+    canAddBackground: Boolean,
     onEffectSelect: (VideoEffect) -> Unit,
+    onAddBackground: (Uri) -> Unit,
+    onDeleteBackground: (VideoBackgroundItem) -> Unit,
     modifier: Modifier = Modifier,
-) {
-}
+) {}

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/BackgroundEffectsRepository.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/BackgroundEffectsRepository.kt
@@ -80,62 +80,7 @@ class BackgroundEffectsRepository(private val context: Context) {
             BackgroundEntry("plane", R.drawable.bg_plane),
             BackgroundEntry("white_room", R.drawable.bg_white_room),
         )
-
-        /**
-         * Returns portrait (width, height) dimensions for the publisher video frame that
-         * corresponds to [resolution].
-         *
-         * OpenTok's Camera2VideoCapturer output pixel dimensions per tier:
-         *   LOW         → 352 × 288 landscape → 288 × 352 portrait
-         *   MEDIUM      → 640 × 480 landscape → 480 × 640 portrait  (3:4)
-         *   HIGH        → 1280 × 720 landscape → 720 × 1280 portrait (9:16)
-         *   HIGH_1080P  → 1920 × 1080 landscape → 1080 × 1920 portrait (9:16)
-         *   null (auto) → defaults to HIGH (most devices ≥ 512 MB)
-         *
-         * Note: if the OpenTok BackgroundReplacement transformer processes frames BEFORE the
-         * camera rotation is applied (i.e., on the raw landscape frame), replace these with
-         * the landscape dimensions (352×288, 640×480, 1280×720, 1920×1080) and validate on
-         * a real device.
-         */
-        @Suppress("MagicNumber")
-        fun portraitDimensionsFor(resolution: CaptureResolution?): Pair<Int, Int> =
-            when (resolution) {
-                CaptureResolution.LOW -> 288 to 352
-                CaptureResolution.MEDIUM -> 480 to 640
-                CaptureResolution.HIGH, null -> 720 to 1280
-                CaptureResolution.HIGH_1080P -> 1080 to 1920
-            }
     }
 }
 
 private data class BackgroundEntry(val id: String, val drawableRes: Int)
-
-/**
- * Returns a new [Bitmap] center-cropped to the given [targetWidth]:[targetHeight] aspect
- * ratio. The source bitmap is NOT recycled here — the caller must recycle it after use.
- *
- * Algorithm:
- *  - If the source is wider than the target ratio → keep full height, crop width.
- *  - If the source is taller than the target ratio → keep full width, crop height.
- *  - If ratios match exactly → return the source unchanged (no allocation).
- */
-private fun Bitmap.centerCropTo(targetWidth: Int, targetHeight: Int): Bitmap {
-    val srcRatio = width.toFloat() / height.toFloat()
-    val dstRatio = targetWidth.toFloat() / targetHeight.toFloat()
-
-    return when {
-        srcRatio > dstRatio -> {
-            // Source is wider → crop left/right
-            val cropWidth = (height * dstRatio).toInt().coerceAtMost(width)
-            val left = (width - cropWidth) / 2
-            Bitmap.createBitmap(this, left, 0, cropWidth, height)
-        }
-        srcRatio < dstRatio -> {
-            // Source is taller → crop top/bottom
-            val cropHeight = (width / dstRatio).toInt().coerceAtMost(height)
-            val top = (height - cropHeight) / 2
-            Bitmap.createBitmap(this, 0, top, width, cropHeight)
-        }
-        else -> this // already the right ratio
-    }
-}

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/ImageCropUtils.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/ImageCropUtils.kt
@@ -1,0 +1,48 @@
+package com.vonage.android.fx.data
+
+import android.graphics.Bitmap
+import com.vonage.android.kotlin.model.CaptureResolution
+
+/**
+ * Returns the portrait (width x height) dimensions for the given [CaptureResolution].
+ *
+ * These dimensions are used to center-crop background images to match the publisher's
+ * video frame aspect ratio before handing the file path to the SDK transformer.
+ */
+@Suppress("MagicNumber")
+internal fun portraitDimensionsFor(resolution: CaptureResolution?): Pair<Int, Int> =
+    when (resolution) {
+        CaptureResolution.LOW -> 288 to 352
+        CaptureResolution.MEDIUM -> 480 to 640
+        CaptureResolution.HIGH, null -> 720 to 1280 // default / most devices
+        CaptureResolution.HIGH_1080P -> 1080 to 1920
+    }
+
+/**
+ * Returns a new [Bitmap] center-cropped to the given [targetWidth]:[targetHeight] aspect ratio.
+ * The source bitmap is NOT recycled here — the caller must recycle it after use.
+ *
+ * - Source wider than target ratio → keep full height, crop left/right.
+ * - Source taller than target ratio → keep full width, crop top/bottom.
+ * - Ratios match exactly → return source unchanged (no allocation).
+ */
+internal fun Bitmap.centerCropTo(targetWidth: Int, targetHeight: Int): Bitmap {
+    val srcRatio = width.toFloat() / height.toFloat()
+    val dstRatio = targetWidth.toFloat() / targetHeight.toFloat()
+
+    return when {
+        srcRatio > dstRatio -> {
+            // Source is wider → crop left/right
+            val cropWidth = (height * dstRatio).toInt().coerceAtMost(width)
+            val left = (width - cropWidth) / 2
+            Bitmap.createBitmap(this, left, 0, cropWidth, height)
+        }
+        srcRatio < dstRatio -> {
+            // Source is taller → crop top/bottom
+            val cropHeight = (width / dstRatio).toInt().coerceAtMost(height)
+            val top = (height - cropHeight) / 2
+            Bitmap.createBitmap(this, 0, top, width, cropHeight)
+        }
+        else -> this // ratios already match
+    }
+}

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/ImageCropUtils.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/ImageCropUtils.kt
@@ -19,18 +19,22 @@ internal fun portraitDimensionsFor(resolution: CaptureResolution?): Pair<Int, In
     }
 
 /**
- * Returns a new [Bitmap] center-cropped to the given [targetWidth]:[targetHeight] aspect ratio.
+ * Returns a new [Bitmap] center-cropped **and scaled** to exactly [targetWidth] × [targetHeight].
  * The source bitmap is NOT recycled here — the caller must recycle it after use.
  *
- * - Source wider than target ratio → keep full height, crop left/right.
- * - Source taller than target ratio → keep full width, crop top/bottom.
- * - Ratios match exactly → return source unchanged (no allocation).
+ * - Step 1 (crop): adjust the aspect ratio by trimming the wider dimension.
+ * - Step 2 (scale): resize the cropped result to the exact target pixel dimensions.
+ *
+ * Any intermediate bitmap created during cropping is recycled internally.
+ * If the source already has the correct ratio and dimensions, it is returned unchanged
+ * (no allocation).
  */
 internal fun Bitmap.centerCropTo(targetWidth: Int, targetHeight: Int): Bitmap {
     val srcRatio = width.toFloat() / height.toFloat()
     val dstRatio = targetWidth.toFloat() / targetHeight.toFloat()
 
-    return when {
+    // Step 1: crop to the correct aspect ratio
+    val cropped: Bitmap = when {
         srcRatio > dstRatio -> {
             // Source is wider → crop left/right
             val cropWidth = (height * dstRatio).toInt().coerceAtMost(width)
@@ -43,6 +47,12 @@ internal fun Bitmap.centerCropTo(targetWidth: Int, targetHeight: Int): Bitmap {
             val top = (height - cropHeight) / 2
             Bitmap.createBitmap(this, 0, top, width, cropHeight)
         }
-        else -> this // ratios already match
+        else -> this // ratios already match — no crop needed
     }
+
+    // Step 2: scale to exact target dimensions (if not already the right size)
+    if (cropped.width == targetWidth && cropped.height == targetHeight) return cropped
+    val scaled = Bitmap.createScaledBitmap(cropped, targetWidth, targetHeight, true)
+    if (cropped !== this) cropped.recycle() // recycle the intermediate crop; caller owns `this`
+    return scaled
 }

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
@@ -94,15 +94,6 @@ class UserBackgroundRepository(private val context: Context) {
         return file.delete()
     }
 
-    /**
-     * Returns the number of stored user backgrounds without constructing the full item list.
-     * Used to compute [canAddBackground] efficiently.
-     */
-    fun getCount(): Int {
-        val dir = File(context.filesDir, USER_BACKGROUNDS_DIR)
-        return dir.listFiles()?.count { it.isFile && it.extension == "jpg" } ?: 0
-    }
-
     companion object {
         /** Configurable upper limit. The "Add image" tile is hidden once this is reached. */
         const val MAX_USER_BACKGROUNDS = 10

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
@@ -61,6 +61,10 @@ class UserBackgroundRepository(private val context: Context) {
         val dir = File(context.filesDir, USER_BACKGROUNDS_DIR)
         dir.mkdirs()
 
+        // Belt-and-suspenders: guard against concurrent or stale-UI saves exceeding the cap.
+        val existingCount = dir.listFiles()?.count { it.isFile && it.extension == "jpg" } ?: 0
+        if (existingCount >= MAX_USER_BACKGROUNDS) return null
+
         val bitmap = context.contentResolver.openInputStream(uri)?.use { stream ->
             BitmapFactory.decodeStream(stream)
         } ?: return null

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/data/UserBackgroundRepository.kt
@@ -1,0 +1,114 @@
+package com.vonage.android.fx.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import com.vonage.android.fx.ui.VideoBackgroundItem
+import com.vonage.android.kotlin.model.CaptureResolution
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
+import java.io.File
+import java.io.FileOutputStream
+
+/**
+ * Manages user-uploaded virtual background images stored in [Context.getFilesDir].
+ *
+ * Images are persisted in `filesDir/user_backgrounds/` as JPEG files, named with a
+ * millisecond timestamp prefix so the directory scan produces a chronological list.
+ * Unlike [BackgroundEffectsRepository] which writes to `cacheDir`, this directory is
+ * never cleared by the system, giving user uploads the same lifetime as app data.
+ *
+ * All IO-bound functions must be called from a background thread (e.g. [kotlinx.coroutines.Dispatchers.IO]).
+ */
+class UserBackgroundRepository(private val context: Context) {
+
+    /**
+     * Scans [filesDir]/user_backgrounds/ and returns one [VideoBackgroundItem] per JPEG.
+     * Items are sorted alphabetically by filename (timestamp prefix → chronological order).
+     * [captureResolution] is accepted for API symmetry with [BackgroundEffectsRepository] but is
+     * not used — images were already cropped to the resolution active at save time.
+     */
+    fun getUserBackgrounds(
+        @Suppress("UnusedParameter") captureResolution: CaptureResolution? = null,
+    ): ImmutableList<VideoBackgroundItem> {
+        val dir = File(context.filesDir, USER_BACKGROUNDS_DIR)
+        if (!dir.exists()) return kotlinx.collections.immutable.persistentListOf()
+        return dir.listFiles()
+            ?.filter { it.isFile && it.extension == "jpg" }
+            ?.sortedBy { it.name }
+            ?.map { file ->
+                VideoBackgroundItem(
+                    id = file.nameWithoutExtension,
+                    thumbnailRes = null,
+                    imagePath = file.absolutePath,
+                    isUserUploaded = true,
+                )
+            }
+            ?.toImmutableList()
+            ?: kotlinx.collections.immutable.persistentListOf()
+    }
+
+    /**
+     * Reads the image at [uri] via [Context.getContentResolver], center-crops it to the
+     * portrait frame dimensions for [captureResolution], and writes a JPEG to
+     * `filesDir/user_backgrounds/<timestamp>.jpg`.
+     *
+     * @return The [VideoBackgroundItem] representing the saved image, or `null` if the URI
+     *         cannot be decoded (e.g. corrupt or inaccessible stream).
+     */
+    fun saveBackground(uri: Uri, captureResolution: CaptureResolution? = null): VideoBackgroundItem? {
+        val dir = File(context.filesDir, USER_BACKGROUNDS_DIR)
+        dir.mkdirs()
+
+        val bitmap = context.contentResolver.openInputStream(uri)?.use { stream ->
+            BitmapFactory.decodeStream(stream)
+        } ?: return null
+
+        val id = "$USER_ID_PREFIX${System.currentTimeMillis()}"
+        val file = File(dir, "$id.jpg")
+
+        val (targetW, targetH) = portraitDimensionsFor(captureResolution)
+        val cropped = bitmap.centerCropTo(targetW, targetH)
+
+        FileOutputStream(file).use { out ->
+            cropped.compress(Bitmap.CompressFormat.JPEG, JPEG_QUALITY, out)
+        }
+        if (cropped !== bitmap) bitmap.recycle()
+        cropped.recycle()
+
+        return VideoBackgroundItem(
+            id = id,
+            thumbnailRes = null,
+            imagePath = file.absolutePath,
+            isUserUploaded = true,
+        )
+    }
+
+    /**
+     * Deletes the background image whose filename (without extension) matches [id].
+     * @return `true` if the file was found and deleted successfully.
+     */
+    fun deleteBackground(id: String): Boolean {
+        val file = File(File(context.filesDir, USER_BACKGROUNDS_DIR), "$id.jpg")
+        return file.delete()
+    }
+
+    /**
+     * Returns the number of stored user backgrounds without constructing the full item list.
+     * Used to compute [canAddBackground] efficiently.
+     */
+    fun getCount(): Int {
+        val dir = File(context.filesDir, USER_BACKGROUNDS_DIR)
+        return dir.listFiles()?.count { it.isFile && it.extension == "jpg" } ?: 0
+    }
+
+    companion object {
+        /** Configurable upper limit. The "Add image" tile is hidden once this is reached. */
+        const val MAX_USER_BACKGROUNDS = 10
+
+        private const val USER_BACKGROUNDS_DIR = "user_backgrounds"
+        private const val USER_ID_PREFIX = "user_bg_"
+        private const val JPEG_QUALITY = 90
+    }
+}

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
@@ -1,5 +1,10 @@
 package com.vonage.android.fx.ui
 
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -19,29 +24,40 @@ import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import com.vonage.android.videofx.R
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.compose.vivid.icons.VividIcons
-import com.vonage.android.compose.vivid.icons.line.BlurOff
+import com.vonage.android.compose.vivid.icons.line.AddImage
 import com.vonage.android.compose.vivid.icons.line.Blur as LineBlur
+import com.vonage.android.compose.vivid.icons.line.BlurOff
+import com.vonage.android.compose.vivid.icons.line.Close
 import com.vonage.android.compose.vivid.icons.solid.Blur as SolidBlur
 import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.videofx.R
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Bottom-sheet content for selecting a video effect.
@@ -51,19 +67,32 @@ import kotlinx.collections.immutable.persistentListOf
  * tap ([onEffectSelect] is called with every selection). There is no Cancel/Apply step —
  * the sheet is dismissed by swiping it down.
  *
- * @param backgrounds    List of virtual background thumbnails to display.
- * @param selectedEffect Currently active video effect (used to highlight the active tile).
- * @param onEffectSelect Invoked when the user taps an effect tile; caller should apply
- *                       it to the publisher immediately.
- * @param modifier       Optional [Modifier] for the root layout.
+ * @param backgrounds       List of virtual background thumbnails to display.
+ * @param selectedEffect    Currently active video effect (used to highlight the active tile).
+ * @param canAddBackground  Whether the "Add image" tile should be shown. Callers hide it once
+ *                          [UserBackgroundRepository.MAX_USER_BACKGROUNDS] is reached.
+ * @param onEffectSelect    Invoked when the user taps an effect tile; caller should apply
+ *                          it to the publisher immediately.
+ * @param onAddBackground   Invoked with the content [Uri] when the user picks an image from
+ *                          the system photo picker. Caller is responsible for IO / file saving.
+ * @param onDeleteBackground Invoked when the user taps the delete button on a user-uploaded
+ *                           background tile.
+ * @param modifier          Optional [Modifier] for the root layout.
  */
 @Composable
 fun VideoEffectsScreen(
     backgrounds: ImmutableList<VideoBackgroundItem>,
     selectedEffect: VideoEffect,
+    canAddBackground: Boolean,
     onEffectSelect: (VideoEffect) -> Unit,
+    onAddBackground: (Uri) -> Unit,
+    onDeleteBackground: (VideoBackgroundItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri -> uri?.let { onAddBackground(it) } }
+
     Column(
         modifier = modifier
             .testTag(VideoEffectsTestTags.VIDEO_EFFECTS_SHEET_CONTENT)
@@ -84,7 +113,14 @@ fun VideoEffectsScreen(
         EffectsAndBackgroundsGrid(
             backgrounds = backgrounds,
             selectedEffect = selectedEffect,
+            canAddBackground = canAddBackground,
             onEffectSelect = onEffectSelect,
+            onAddImageClick = {
+                launcher.launch(
+                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+                )
+            },
+            onDeleteBackground = onDeleteBackground,
             modifier = Modifier.padding(horizontal = VonageVideoTheme.dimens.paddingDefault),
         )
     }
@@ -94,7 +130,10 @@ fun VideoEffectsScreen(
 private fun EffectsAndBackgroundsGrid(
     backgrounds: ImmutableList<VideoBackgroundItem>,
     selectedEffect: VideoEffect,
+    canAddBackground: Boolean,
     onEffectSelect: (VideoEffect) -> Unit,
+    onAddImageClick: () -> Unit,
+    onDeleteBackground: (VideoBackgroundItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val blurEffects = remember {
@@ -104,6 +143,10 @@ private fun EffectsAndBackgroundsGrid(
             VideoEffect.BlurHigh to VividIcons.Solid.SolidBlur,
         )
     }
+
+    // Show the backgrounds section when there are existing backgrounds OR when a new one can be added.
+    val showBackgroundsSection = backgrounds.isNotEmpty() || canAddBackground
+
     LazyVerticalGrid(
         columns = GridCells.Fixed(GRID_COLUMNS),
         modifier = modifier,
@@ -135,12 +178,12 @@ private fun EffectsAndBackgroundsGrid(
             }
         }
 
-        if (backgrounds.isNotEmpty()) {
+        if (showBackgroundsSection) {
             // Backgrounds section header
             item(span = { GridItemSpan(maxCurrentLineSpan) }) {
                 SectionHeader(text = stringResource(R.string.video_effects_section_backgrounds))
             }
-            // Background thumbnails
+            // Background thumbnails (built-in and user-uploaded)
             items(items = backgrounds, key = { it.id }) { item ->
                 BackgroundThumbnail(
                     item = item,
@@ -150,7 +193,21 @@ private fun EffectsAndBackgroundsGrid(
                         val path = item.imagePath ?: return@BackgroundThumbnail
                         onEffectSelect(VideoEffect.BackgroundImage(id = item.id, imagePath = path))
                     },
+                    onDelete = if (item.isUserUploaded) {
+                        { onDeleteBackground(item) }
+                    } else {
+                        null
+                    },
                 )
+            }
+            // "Add image" tile — shown when the user has not yet reached the limit
+            if (canAddBackground) {
+                item {
+                    AddBackgroundTile(
+                        modifier = Modifier.testTag(VideoEffectsTestTags.VIDEO_EFFECTS_ADD_BACKGROUND_TILE),
+                        onClick = onAddImageClick,
+                    )
+                }
             }
         }
     }
@@ -213,10 +270,27 @@ private fun BackgroundThumbnail(
     item: VideoBackgroundItem,
     isSelected: Boolean,
     onClick: () -> Unit,
+    onDelete: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
     val primary = VonageVideoTheme.colors.primary
     val borderColor = if (isSelected) primary else Color.Transparent
+
+    // For user-uploaded images (thumbnailRes == null), load the bitmap from disk asynchronously.
+    val painter: Painter = if (item.thumbnailRes != null) {
+        painterResource(item.thumbnailRes)
+    } else {
+        val bitmap by produceState<android.graphics.Bitmap?>(initialValue = null, item.imagePath) {
+            value = withContext(Dispatchers.IO) {
+                item.imagePath?.let { path ->
+                    runCatching { BitmapFactory.decodeFile(path) }.getOrNull()
+                }
+            }
+        }
+        remember(bitmap) {
+            bitmap?.asImageBitmap()?.let { BitmapPainter(it) } ?: ColorPainter(Color.DarkGray)
+        }
+    }
 
     Box(
         modifier = modifier
@@ -230,21 +304,73 @@ private fun BackgroundThumbnail(
             )
             .clickable { onClick() },
     ) {
-        if (item.thumbnailRes != null) {
-            Image(
-                painter = painterResource(item.thumbnailRes),
-                contentDescription = null,
-                contentScale = ContentScale.Crop,
-                modifier = Modifier.fillMaxSize(),
-            )
+        Image(
+            painter = painter,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        // Delete affordance — only for user-uploaded backgrounds
+        if (onDelete != null) {
+            IconButton(
+                onClick = onDelete,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .testTag(VideoEffectsTestTags.VIDEO_EFFECTS_DELETE_BACKGROUND_BUTTON)
+                    .padding(DELETE_BUTTON_PADDING.dp)
+                    .size(DELETE_BUTTON_SIZE.dp)
+                    .background(
+                        color = Color.Black.copy(alpha = DELETE_SCRIM_ALPHA),
+                        shape = VonageVideoTheme.shapes.small,
+                    ),
+            ) {
+                Icon(
+                    imageVector = VividIcons.Line.Close,
+                    contentDescription = stringResource(R.string.video_effects_delete_background_description),
+                    tint = Color.White,
+                    modifier = Modifier.size(DELETE_ICON_SIZE.dp),
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun AddBackgroundTile(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(THUMBNAIL_ASPECT_RATIO)
+            .clip(VonageVideoTheme.shapes.medium)
+            .background(VonageVideoTheme.colors.surface)
+            .border(
+                BorderStroke(VonageVideoTheme.dimens.borderWidthDefault, Color.Transparent),
+                VonageVideoTheme.shapes.medium
+            )
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = VividIcons.Line.AddImage,
+            contentDescription = stringResource(R.string.video_effects_add_background),
+            tint = VonageVideoTheme.colors.secondary,
+            modifier = Modifier.size(VonageVideoTheme.dimens.iconSizeDefault),
+        )
     }
 }
 
 private const val THUMBNAIL_ASPECT_RATIO = 16f / 9f
 private const val EFFECT_ICON_SIZE = 56
-private const val GRID_COLUMNS = 2
+private const val GRID_COLUMNS = 3
 private const val SELECTED_ALPHA = 0.12f
+private const val DELETE_BUTTON_PADDING = 4
+private const val DELETE_BUTTON_SIZE = 24
+private const val DELETE_ICON_SIZE = 16
+private const val DELETE_SCRIM_ALPHA = 0.5f
 
 @Preview(showBackground = true)
 @Composable
@@ -254,13 +380,16 @@ internal fun VideoEffectsScreenPortraitPreview() {
             backgrounds = persistentListOf(
                 VideoBackgroundItem(id = "bg1"),
                 VideoBackgroundItem(id = "bg2"),
-                VideoBackgroundItem(id = "bg3"),
+                VideoBackgroundItem(id = "bg3", isUserUploaded = true),
                 VideoBackgroundItem(id = "bg4"),
                 VideoBackgroundItem(id = "bg5"),
                 VideoBackgroundItem(id = "bg6"),
             ),
             selectedEffect = VideoEffect.None,
+            canAddBackground = true,
             onEffectSelect = {},
+            onAddBackground = {},
+            onDeleteBackground = {},
         )
     }
 }
@@ -277,7 +406,10 @@ internal fun VideoEffectsScreenLandscapePreview() {
                 VideoBackgroundItem(id = "bg4"),
             ),
             selectedEffect = VideoEffect.BlurLow,
+            canAddBackground = false,
             onEffectSelect = {},
+            onAddBackground = {},
+            onDeleteBackground = {},
         )
     }
 }

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
@@ -277,13 +277,20 @@ private fun BackgroundThumbnail(
     val borderColor = if (isSelected) primary else Color.Transparent
 
     // For user-uploaded images (thumbnailRes == null), load the bitmap from disk asynchronously.
+    // Use inSampleSize to decode a thumbnail-sized bitmap rather than the full saved image.
     val painter: Painter = if (item.thumbnailRes != null) {
         painterResource(item.thumbnailRes)
     } else {
         val bitmap by produceState<android.graphics.Bitmap?>(initialValue = null, item.imagePath) {
             value = withContext(Dispatchers.IO) {
                 item.imagePath?.let { path ->
-                    runCatching { BitmapFactory.decodeFile(path) }.getOrNull()
+                    runCatching {
+                        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+                        BitmapFactory.decodeFile(path, opts)
+                        opts.inSampleSize = calculateInSampleSize(opts, THUMBNAIL_TARGET_PX, THUMBNAIL_TARGET_PX)
+                        opts.inJustDecodeBounds = false
+                        BitmapFactory.decodeFile(path, opts)
+                    }.getOrNull()
                 }
             }
         }
@@ -364,6 +371,8 @@ private fun AddBackgroundTile(
 }
 
 private const val THUMBNAIL_ASPECT_RATIO = 16f / 9f
+/** Target pixel size used for inSampleSize calculation when decoding user-uploaded thumbnails. */
+private const val THUMBNAIL_TARGET_PX = 256
 private const val EFFECT_ICON_SIZE = 56
 private const val GRID_COLUMNS = 3
 private const val SELECTED_ALPHA = 0.12f
@@ -412,4 +421,21 @@ internal fun VideoEffectsScreenLandscapePreview() {
             onDeleteBackground = {},
         )
     }
+}
+
+/**
+ * Calculates the largest power-of-2 [BitmapFactory.Options.inSampleSize] such that the decoded
+ * bitmap is still at least [reqWidth] × [reqHeight] pixels. This avoids loading the full
+ * high-resolution file into memory when only a small thumbnail is needed.
+ */
+private fun calculateInSampleSize(opts: BitmapFactory.Options, reqWidth: Int, reqHeight: Int): Int {
+    var sampleSize = 1
+    if (opts.outHeight > reqHeight || opts.outWidth > reqWidth) {
+        val halfH = opts.outHeight / 2
+        val halfW = opts.outWidth / 2
+        while (halfH / sampleSize >= reqHeight && halfW / sampleSize >= reqWidth) {
+            sampleSize *= 2
+        }
+    }
+    return sampleSize
 }

--- a/vonage-feature-video-effects/src/main/java/com/vonage/android/fx/ui/VideoBackgroundItem.kt
+++ b/vonage-feature-video-effects/src/main/java/com/vonage/android/fx/ui/VideoBackgroundItem.kt
@@ -6,11 +6,15 @@ import androidx.annotation.DrawableRes
  * A virtual background option displayed in the background selection grid.
  *
  * @property id Unique identifier for the background.
- * @property thumbnailRes Optional drawable resource for the thumbnail preview.
+ * @property thumbnailRes Optional drawable resource for the thumbnail preview. Null for
+ *   user-uploaded images, which load their preview from [imagePath] at runtime.
  * @property imagePath Absolute file path to the image for the SDK background replacement.
+ * @property isUserUploaded Whether this background was uploaded by the user. User-uploaded
+ *   tiles show a delete affordance in the effects sheet.
  */
 data class VideoBackgroundItem(
     val id: String,
     @DrawableRes val thumbnailRes: Int? = null,
     val imagePath: String? = null,
+    val isUserUploaded: Boolean = false,
 )

--- a/vonage-feature-video-effects/src/main/java/com/vonage/android/fx/ui/VideoEffectsTestTags.kt
+++ b/vonage-feature-video-effects/src/main/java/com/vonage/android/fx/ui/VideoEffectsTestTags.kt
@@ -5,4 +5,6 @@ object VideoEffectsTestTags {
     const val VIDEO_EFFECTS_NONE_TILE = "video_effects_none_tile"
     const val VIDEO_EFFECTS_BLUR_LOW_TILE = "video_effects_blur_low_tile"
     const val VIDEO_EFFECTS_BLUR_HIGH_TILE = "video_effects_blur_high_tile"
+    const val VIDEO_EFFECTS_ADD_BACKGROUND_TILE = "video_effects_add_background_tile"
+    const val VIDEO_EFFECTS_DELETE_BACKGROUND_BUTTON = "video_effects_delete_background_button"
 }

--- a/vonage-feature-video-effects/src/main/res/values/strings.xml
+++ b/vonage-feature-video-effects/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="video_effects_title">Video effects</string>
     <string name="video_effects_section_effects">Effects</string>
     <string name="video_effects_section_backgrounds">Backgrounds</string>
+    <string name="video_effects_add_background">Add image</string>
+    <string name="video_effects_delete_background_description">Delete background</string>
 </resources>

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/MeetingRoomContent.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/MeetingRoomContent.kt
@@ -125,6 +125,8 @@ private fun MeetingRoomContentInner(
             onSettings = { prebuilt.onAction(MeetingRoomSDKAction.NavigateToSettings) },
             onTogglePinParticipant = viewModel::onTogglePinParticipant,
             onForceMuteParticipant = viewModel::forceMuteParticipant,
+            onAddBackground = viewModel::addBackground,
+            onDeleteBackground = viewModel::deleteBackground,
         )
     }
 

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/container/MeetingRoomContainer.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/container/MeetingRoomContainer.kt
@@ -5,6 +5,7 @@ import com.vonage.android.archiving.VonageArchiving
 import com.vonage.android.captions.VonageCaptions
 import com.vonage.android.chat.ChatModule
 import com.vonage.android.fx.data.BackgroundEffectsRepository
+import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.kotlin.VonageVideoClient
 import com.vonage.android.kotlin.internal.PublisherFactory
 import com.vonage.android.kotlin.sdk.VonageSdkFactory
@@ -119,5 +120,9 @@ internal class MeetingRoomContainer(
 
     val backgroundEffectsRepository: BackgroundEffectsRepository by lazy {
         BackgroundEffectsRepository(applicationContext)
+    }
+
+    val userBackgroundRepository: UserBackgroundRepository by lazy {
+        UserBackgroundRepository(applicationContext)
     }
 }

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomActions.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomActions.kt
@@ -1,6 +1,8 @@
 package com.vonage.android.meetingroom.internal.screen
 
+import android.net.Uri
 import androidx.compose.runtime.Stable
+import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.VideoEffect
 
 @Stable
@@ -25,4 +27,6 @@ internal data class MeetingRoomActions(
     val onSettings: () -> Unit = {},
     val onTogglePinParticipant: (String) -> Unit = {},
     val onForceMuteParticipant: (String) -> Unit = {},
+    val onAddBackground: (Uri) -> Unit = {},
+    val onDeleteBackground: (VideoBackgroundItem) -> Unit = {},
 )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
@@ -129,6 +129,16 @@ internal fun MeetingRoomScreen(
                     selectedEffect = publisher?.videoEffect?.value ?: VideoEffect.None
                 }
             }
+            // If the user deletes the active background while the sheet is open, reset the
+            // local selection so the grid no longer highlights a non-existent item.
+            LaunchedEffect(uiState.backgrounds) {
+                val current = selectedEffect
+                if (current is VideoEffect.BackgroundImage &&
+                    uiState.backgrounds.none { it.id == current.id }
+                ) {
+                    selectedEffect = VideoEffect.None
+                }
+            }
 
             Scaffold(
                 modifier = modifier.systemBarsPadding(),
@@ -234,10 +244,13 @@ internal fun MeetingRoomScreen(
                     VideoEffectsScreen(
                         backgrounds = uiState.backgrounds,
                         selectedEffect = selectedEffect,
+                        canAddBackground = uiState.canAddBackground,
                         onEffectSelect = { effect ->
                             selectedEffect = effect
                             actions.onApplyVideoEffect(effect)
                         },
+                        onAddBackground = actions.onAddBackground,
+                        onDeleteBackground = actions.onDeleteBackground,
                     )
                 }
             }

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
@@ -131,9 +131,12 @@ internal fun MeetingRoomScreen(
             }
             // If the user deletes the active background while the sheet is open, reset the
             // local selection so the grid no longer highlights a non-existent item.
+            // Guard with isNotEmpty() so the effect doesn't fire while the list is still
+            // loading (empty initial state would otherwise clear any active selection).
             LaunchedEffect(uiState.backgrounds) {
                 val current = selectedEffect
                 if (current is VideoEffect.BackgroundImage &&
+                    uiState.backgrounds.isNotEmpty() &&
                     uiState.backgrounds.none { it.id == current.id }
                 ) {
                     selectedEffect = VideoEffect.None

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
@@ -28,6 +28,8 @@ internal data class MeetingRoomUiState(
     val allowCameraControl: Boolean = true,
     val allowShowParticipantList: Boolean = true,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
+    /** Whether the "Add image" tile should be shown in the effects sheet. */
+    val canAddBackground: Boolean = true,
     /** Runtime feature set — applied on top of compile-time flavor toggles. */
     val enabledFeatures: Set<MeetingRoomFeature> = MeetingRoomFeature.all,
 )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -2,10 +2,13 @@ package com.vonage.android.meetingroom.internal.viewmodel
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vonage.android.archiving.ArchivingUiState
 import com.vonage.android.captions.CaptionsUiState
+import com.vonage.android.fx.data.UserBackgroundRepository
+import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.ArchivingState
 import com.vonage.android.kotlin.model.CallFacade
 import com.vonage.android.kotlin.model.PublisherConfig
@@ -22,6 +25,7 @@ import com.vonage.android.screensharing.ScreenSharingState
 import com.vonage.logger.vonageLogger
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +39,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Suppress("LongParameterList")
 internal class MeetingRoomViewModel(
@@ -85,16 +90,7 @@ internal class MeetingRoomViewModel(
             ),
         )
 
-        viewModelScope.launch(Dispatchers.IO) {
-            val backgrounds = runCatching {
-                container.backgroundEffectsRepository.getBackgrounds(
-                    container.callSettingsHolder.captureResolution.value,
-                )
-            }.onFailure { throwable ->
-                vonageLogger.e("MeetingRoomViewModel", "Failed to load background effects: $throwable")
-            }.getOrElse { persistentListOf() }
-            _uiState.update { it.copy(backgrounds = backgrounds) }
-        }
+        viewModelScope.launch(Dispatchers.IO) { refreshBackgrounds() }
 
         viewModelScope.launch {
             _uiState.update { state ->
@@ -206,6 +202,55 @@ internal class MeetingRoomViewModel(
      */
     fun applyVideoEffect(effect: VideoEffect) {
         call?.applyLocalVideoEffect(effect)
+    }
+
+    /**
+     * Saves the image at [uri] to persistent storage and refreshes the backgrounds list.
+     * Must be called from any thread; IO is performed internally on [Dispatchers.IO].
+     */
+    fun addBackground(uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val resolution = container.callSettingsHolder.captureResolution.value
+            container.userBackgroundRepository.saveBackground(uri, resolution)
+            refreshBackgrounds()
+        }
+    }
+
+    /**
+     * Deletes the user-uploaded background identified by [item]. If the deleted background is
+     * currently active on the publisher, the effect is reset to [VideoEffect.None].
+     */
+    fun deleteBackground(item: VideoBackgroundItem) {
+        viewModelScope.launch(Dispatchers.IO) {
+            container.userBackgroundRepository.deleteBackground(item.id)
+            val currentEffect = call?.publisher?.value?.videoEffect?.value
+            if (currentEffect is VideoEffect.BackgroundImage && currentEffect.id == item.id) {
+                withContext(Dispatchers.Main) { applyVideoEffect(VideoEffect.None) }
+            }
+            refreshBackgrounds()
+        }
+    }
+
+    /**
+     * Merges built-in and user-uploaded backgrounds then updates the UI state.
+     * Must be called from [Dispatchers.IO].
+     */
+    private suspend fun refreshBackgrounds() {
+        val resolution = container.callSettingsHolder.captureResolution.value
+        val builtIn = runCatching {
+            container.backgroundEffectsRepository.getBackgrounds(resolution)
+        }.onFailure { throwable ->
+            vonageLogger.e("MeetingRoomViewModel", "Failed to load built-in backgrounds: $throwable")
+        }.getOrElse { persistentListOf() }
+
+        val user = runCatching {
+            container.userBackgroundRepository.getUserBackgrounds(resolution)
+        }.onFailure { throwable ->
+            vonageLogger.e("MeetingRoomViewModel", "Failed to load user backgrounds: $throwable")
+        }.getOrElse { persistentListOf() }
+
+        val canAdd = user.size < UserBackgroundRepository.MAX_USER_BACKGROUNDS
+        _uiState.update { it.copy(backgrounds = (builtIn + user).toImmutableList(), canAddBackground = canAdd) }
     }
 
     fun endCall() {


### PR DESCRIPTION
## Summary

- Users can now pick images from the Android Photo Picker and use them as virtual backgrounds — stored persistently under `filesDir/user_backgrounds/` (never cleared by the system)
- Uploaded backgrounds appear as tiles in `VideoEffectsScreen` alongside built-ins, with a delete button overlay; the "+" add tile is hidden once `MAX_USER_BACKGROUNDS = 10` is reached
- Applies to both the **MeetingRoom** and **WaitingRoom** flows

## Changes

### New files
- `ImageCropUtils.kt` — shared `centerCropTo` / `portraitDimensionsFor` helpers extracted from `BackgroundEffectsRepository`
- `UserBackgroundRepository.kt` (enabled flavor) — scan, save, delete, count; all IO-bound
- `UserBackgroundRepository.kt` (disabled flavor) — no-op stub matching the same public API

### Modified
- `VideoEffectsScreen` (enabled) — Android Photo Picker launcher, composable `AddBackgroundTile` ("+"), delete `IconButton` overlay, async thumbnail loading via `produceState` + `BitmapFactory.decodeFile`
- `VideoEffectsScreen` (disabled) — stub signature updated to match
- `VideoBackgroundItem` — added `isUserUploaded: Boolean = false`
- `VideoEffectsTestTags` — two new tag constants
- `strings.xml` — two new string resources
- `MeetingRoomViewModel` / `WaitingRoomViewModel` — `addBackground(Uri)`, `deleteBackground(item)`, `refreshBackgrounds()`; `canAddBackground` derived from user list size
- `MeetingRoomUiState` / `WaitingRoomUiState` — `canAddBackground` field
- `MeetingRoomActions` / `WaitingRoomActions` / route composables — new callbacks wired end-to-end
- `MeetingRoomScreen` / `WaitingRoomScreen` — `LaunchedEffect(uiState.backgrounds)` resets selected effect when the active background is deleted while the sheet is open

## Testing

- All unit tests pass (`WaitingRoomViewModelTest` 9/9, `MeetingRoomViewModel` full suite)
- Detekt passes (pre-push hook verified on push)

## Notes

- `canAddBackground` is now derived from `user.size` rather than a separate `getCount()` directory scan — eliminates redundant IO and the NPE that occurred in tests where `context.filesDir` is a relaxed mock

---
> This PR was generated with AI assistance.