### PR TITLE
VIDSOL-816: fix waiting-room state not propagating to meeting room SDK

### DIFF
--- a/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
@@ -1,6 +1,7 @@
 package com.vonage.android.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -36,7 +37,7 @@ fun AppNavHost(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    var pendingPublisherSettings by remember { mutableStateOf(PublisherSettings()) }
+    var pendingPublisherSettings by remember { mutableStateOf<PublisherSettings?>(null) }
     NavHost(
         modifier = modifier,
         navController = navController,
@@ -77,9 +78,14 @@ fun AppNavHost(
             )
         ) { backStackEntry ->
             val roomName = backStackEntry.toRoute<Meeting>().roomName
+            // Capture once per navigation event; re-entry that bypasses the waiting room
+            // (e.g. Goodbye → Re-enter) will find null here and receive clean defaults.
+            val settings = remember(roomName) { pendingPublisherSettings ?: PublisherSettings() }
+            // Reset so any future arrival at Meeting without a waiting-room join gets defaults.
+            SideEffect { pendingPublisherSettings = null }
             MeetingRoomScreenRoute(
                 roomName = roomName,
-                initialPublisherSettings = pendingPublisherSettings,
+                initialPublisherSettings = settings,
                 navigateToGoodBye = { navController.navigate(Goodbye(roomName = roomName)) },
                 navigateToShare = { roomName -> context.navigateToShare(roomName) },
                 navigateToSettings = { navController.navigate(Settings) },

--- a/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
@@ -16,7 +16,7 @@ import androidx.navigation.compose.dialog
 import androidx.navigation.navDeepLink
 import androidx.navigation.toRoute
 import com.vonage.android.BuildConfig
-import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.navigation.AppRoute.Goodbye
 import com.vonage.android.navigation.AppRoute.Landing
 import com.vonage.android.navigation.AppRoute.Meeting
@@ -36,7 +36,7 @@ fun AppNavHost(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
-    var pendingVideoEffect by remember { mutableStateOf<VideoEffect>(VideoEffect.None) }
+    var pendingPublisherSettings by remember { mutableStateOf(PublisherSettings()) }
     NavHost(
         modifier = modifier,
         navController = navController,
@@ -55,8 +55,8 @@ fun AppNavHost(
             val roomName = backStackEntry.toRoute<Waiting>().roomName
             WaitingRoomRoute(
                 roomName = roomName,
-                navigateToRoom = { roomName, videoEffect ->
-                    pendingVideoEffect = videoEffect
+                navigateToRoom = { roomName, settings ->
+                    pendingPublisherSettings = settings
                     navController.navigate(
                         route = Meeting(roomName),
                         navOptions = NavOptions.Builder().setLaunchSingleTop(true).build(),
@@ -79,7 +79,7 @@ fun AppNavHost(
             val roomName = backStackEntry.toRoute<Meeting>().roomName
             MeetingRoomScreenRoute(
                 roomName = roomName,
-                initialVideoEffect = pendingVideoEffect,
+                initialPublisherSettings = pendingPublisherSettings,
                 navigateToGoodBye = { navController.navigate(Goodbye(roomName = roomName)) },
                 navigateToShare = { roomName -> context.navigateToShare(roomName) },
                 navigateToSettings = { navController.navigate(Settings) },

--- a/app/src/main/java/com/vonage/android/screen/room/MeetingRoomScreenRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/room/MeetingRoomScreenRoute.kt
@@ -4,7 +4,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.vonage.android.BuildConfig
 import com.vonage.android.config.AppConfig
-import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.meetingroom.api.MeetingRoomBuilder
 import com.vonage.android.meetingroom.api.MeetingRoomConfiguration
 import com.vonage.android.meetingroom.api.MeetingRoomSDKAction
@@ -23,16 +22,14 @@ fun MeetingRoomScreenRoute(
     navigateToGoodBye: () -> Unit,
     navigateToShare: (String) -> Unit,
     navigateToSettings: () -> Unit,
-    initialVideoEffect: VideoEffect = VideoEffect.None,
+    initialPublisherSettings: PublisherSettings = PublisherSettings(),
 ) {
-    val prebuilt = remember(roomName, initialVideoEffect) {
+    val prebuilt = remember(roomName, initialPublisherSettings) {
         MeetingRoomBuilder(
             baseUrl = BuildConfig.BASE_API_URL,
             roomName = roomName,
         )
-            .publisherSettings(
-                PublisherSettings(initialVideoEffect = initialVideoEffect)
-            )
+            .publisherSettings(initialPublisherSettings)
             .configuration(
                 MeetingRoomConfiguration(
                     allowCameraControl = AppConfig.VideoSettings.ALLOW_CAMERA_CONTROL,

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
@@ -15,13 +15,14 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.screen.components.permissions.CallPermissionHandler
 import com.vonage.android.util.pip.pipEffect
 
 @Composable
 fun WaitingRoomRoute(
     roomName: String,
-    navigateToRoom: (String, VideoEffect) -> Unit,
+    navigateToRoom: (String, PublisherSettings) -> Unit,
     navigateToPermissions: () -> Unit,
     navigateToSettings: () -> Unit,
     onBack: () -> Unit,

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
@@ -27,6 +27,7 @@ import com.vonage.android.compose.layout.TwoPaneScaffold
 import com.vonage.android.compose.preview.buildPublisher
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.fx.ui.VideoEffectsScreen
 import com.vonage.android.screen.components.audio.AudioDevicesMenu
 import com.vonage.android.screen.waiting.components.DeviceSelectionPanel
@@ -44,7 +45,7 @@ fun WaitingRoomScreen(
     uiState: WaitingRoomUiState,
     actions: WaitingRoomActions,
     modifier: Modifier = Modifier,
-    navigateToRoom: (String, VideoEffect) -> Unit = { _, _ -> },
+    navigateToRoom: (String, PublisherSettings) -> Unit = { _, _ -> },
     navigateToSettings: () -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
@@ -63,7 +64,7 @@ fun WaitingRoomScreen(
 
     LaunchedEffect(uiState.isSuccess) {
         if (uiState.isSuccess) {
-            navigateToRoom(uiState.roomName, uiState.joinEffect)
+            navigateToRoom(uiState.roomName, uiState.joinSettings)
         }
     }
 

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -143,7 +143,7 @@ class WaitingRoomViewModel @AssistedInject constructor(
     fun joinRoom(userName: String) {
         viewModelScope.launch {
             val sanitizedUserName = userName.sanitizeUserName()
-            if (userName.isValidUserName().not()) {
+            if (sanitizedUserName.isValidUserName().not()) {
                 _uiState.update { uiState -> uiState.copy(isUserNameValid = false) }
                 return@launch
             }

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -10,6 +10,7 @@ import com.vonage.android.fx.data.BackgroundEffectsRepository
 import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.settings.CallSettingsHolder
 import com.vonage.android.data.UserRepository
 import com.vonage.android.kotlin.VonageVideoClient
@@ -147,13 +148,15 @@ class WaitingRoomViewModel @AssistedInject constructor(
                 return@launch
             }
             userRepository.saveUserName(sanitizedUserName)
-            val joinEffect = currentPublisher()?.let { publisher ->
+            val joinSettings = currentPublisher()?.let { publisher ->
                 val effect = publisher.videoEffect.value
+                val publishAudio = publisher.isMicEnabled.value
+                val publishVideo = publisher.isCameraEnabled.value
                 videoClient.configurePublisher(
                     PublisherConfig(
                         name = sanitizedUserName,
-                        publishVideo = publisher.isCameraEnabled.value,
-                        publishAudio = publisher.isMicEnabled.value,
+                        publishVideo = publishVideo,
+                        publishAudio = publishAudio,
                         initialVideoEffect = effect,
                         cameraIndex = publisher.camera.value.index,
                         senderStatsTrack = callSettingsHolder.senderStatsEnabled.value,
@@ -164,10 +167,15 @@ class WaitingRoomViewModel @AssistedInject constructor(
                         captureFrameRate = callSettingsHolder.captureFrameRate.value,
                     )
                 )
-                effect
-            } ?: VideoEffect.None
+                PublisherSettings(
+                    username = sanitizedUserName,
+                    publishAudio = publishAudio,
+                    publishVideo = publishVideo,
+                    initialVideoEffect = effect,
+                )
+            } ?: PublisherSettings(username = sanitizedUserName)
             onStop()
-            _uiState.update { uiState -> uiState.copy(isSuccess = true, joinEffect = joinEffect) }
+            _uiState.update { uiState -> uiState.copy(isSuccess = true, joinSettings = joinSettings) }
         }
     }
 
@@ -279,7 +287,7 @@ data class WaitingRoomUiState(
     val isUserNameValid: Boolean = true,
     val publisher: PublisherParticipant? = null,
     val isSuccess: Boolean = false,
-    val joinEffect: VideoEffect = VideoEffect.None,
+    val joinSettings: PublisherSettings = PublisherSettings(),
     val allowMicrophoneControl: Boolean = true,
     val allowCameraControl: Boolean = true,
     val audioDevicesState: AudioDevicesState? = null,

--- a/app/src/main/java/com/vonage/android/util/isValidUserName.kt
+++ b/app/src/main/java/com/vonage/android/util/isValidUserName.kt
@@ -3,7 +3,7 @@ package com.vonage.android.util
 const val MAX_USER_NAME_LENGTH = 60
 
 fun String.isValidUserName(): Boolean =
-    trim().let { length in 1..MAX_USER_NAME_LENGTH }
+    trim().length in 1..MAX_USER_NAME_LENGTH
 
 fun String.sanitizeUserName(): String =
     trim().replace("\\s{2,}".toRegex(), " ")

--- a/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
@@ -12,6 +12,7 @@ import com.vonage.android.kotlin.model.CaptureFrameRate
 import com.vonage.android.kotlin.model.PreviewPublisherState
 import com.vonage.android.kotlin.model.VideoBitrateConfig
 import com.vonage.android.kotlin.model.VideoEffect
+import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.screen.components.audio.AudioDevicesHandler
 import com.vonage.android.settings.CallSettingsHolder
 import io.mockk.coEvery
@@ -166,11 +167,40 @@ class WaitingRoomViewModelTest {
             awaitItem()
             sut.init(context)
             sut.joinRoom("save user name")
-            assertTrue(awaitItem().isSuccess)
+            val state = awaitItem()
+            assertTrue(state.isSuccess)
+            assertEquals("save user name", state.joinSettings.username)
         }
 
         coVerify { userRepository.saveUserName("save user name") }
         verify { videoClient.destroyPublisher() }
+    }
+
+    @Test
+    fun `given initialized viewmodel when join room then joinSettings contains publisher state`() = runTest {
+        coEvery { userRepository.getUserName() } returns "initial"
+        coEvery { userRepository.saveUserName(any()) } returns Unit
+        givenPreviewPublisher()
+        every { videoClient.configurePublisher(any()) } returns Unit
+        every { videoClient.destroyPublisher() } returns Unit
+
+        sut.uiState.test {
+            awaitItem() // initial state
+            sut.init(context)
+            awaitItem() // post-init: publisher is now set in _uiState
+            sut.joinRoom("Alice")
+            val state = awaitItem() // post-join state
+            assertTrue(state.isSuccess)
+            assertEquals(
+                PublisherSettings(
+                    username = "Alice",
+                    publishAudio = false,      // isMicEnabled = false per buildMockPublisher()
+                    publishVideo = true,       // isCameraEnabled = true per buildMockPublisher()
+                    initialVideoEffect = VideoEffect.None,
+                ),
+                state.joinSettings,
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
@@ -23,6 +23,7 @@ import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -164,16 +165,36 @@ class WaitingRoomViewModelTest {
         every { videoClient.destroyPublisher() } returns Unit
 
         sut.uiState.test {
-            awaitItem()
+            awaitItem()                // initial state
             sut.init(context)
+            awaitItem()                // post-init: publisher now set in uiState
             sut.joinRoom("save user name")
-            val state = awaitItem()
+            val state = awaitItem()    // post-join: isSuccess = true
             assertTrue(state.isSuccess)
             assertEquals("save user name", state.joinSettings.username)
         }
 
         coVerify { userRepository.saveUserName("save user name") }
         verify { videoClient.destroyPublisher() }
+    }
+
+    @Test
+    fun `given viewmodel when join room with whitespace-only name then state is invalid and room is not joined`() = runTest {
+        coEvery { userRepository.getUserName() } returns "initial"
+        givenPreviewPublisher()
+        every { videoClient.destroyPublisher() } returns Unit
+
+        sut.uiState.test {
+            awaitItem()                // initial state
+            sut.init(context)
+            awaitItem()                // post-init: publisher now set in uiState
+            sut.joinRoom("   ")        // whitespace-only — trimmed to empty, must be rejected
+            val state = awaitItem()
+            assertFalse(state.isSuccess)
+            assertFalse(state.isUserNameValid)
+        }
+
+        coVerify(exactly = 0) { userRepository.saveUserName(any()) }
     }
 
     @Test

--- a/app/src/test/java/com/vonage/android/util/IsValidUserNameTest.kt
+++ b/app/src/test/java/com/vonage/android/util/IsValidUserNameTest.kt
@@ -1,0 +1,29 @@
+package com.vonage.android.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class IsValidUserNameTest {
+
+    @ParameterizedTest
+    @MethodSource("userNames")
+    fun `should validate user name`(input: String, isValid: Boolean) {
+        assertEquals(isValid, input.isValidUserName())
+    }
+
+    companion object {
+        @JvmStatic
+        fun userNames() = listOf(
+            Arguments.of("Alice", true),
+            Arguments.of("  Alice  ", true),          // leading/trailing spaces trimmed → valid
+            Arguments.of("a", true),
+            Arguments.of("a".repeat(MAX_USER_NAME_LENGTH), true),
+            Arguments.of("a".repeat(MAX_USER_NAME_LENGTH + 1), false),
+            Arguments.of("", false),
+            Arguments.of("   ", false),               // whitespace-only → empty after trim
+            Arguments.of(" ", false),                 // single space → empty after trim
+        )
+    }
+}


### PR DESCRIPTION
## Summary

When a user configured their username, microphone state, camera state, or video effect in the waiting room and tapped **Join**, only the video effect was forwarded to the meeting room SDK. Username defaulted to empty string, and mic/camera always started enabled regardless of what the user had set.

**Root cause:** `MeetingRoomScreenRoute` constructed `PublisherSettings(initialVideoEffect = ...)` — only one of four fields. The other three values were captured inside `WaitingRoomViewModel.joinRoom()` from the live `PublisherParticipant` and written into the app-scoped `VonageVideoClient`, but the `MeetingRoomContainer` uses its own separate `VonageVideoClient` instance and never received them.

**Fix:** `joinRoom()` now snapshots all four join-time values (`username`, `publishAudio`, `publishVideo`, `initialVideoEffect`) into a `PublisherSettings` object stored on `WaitingRoomUiState.joinSettings`. This is threaded through the navigation chain as `pendingPublisherSettings` and passed in full to `MeetingRoomBuilder.publisherSettings()`.

## Changes

- `WaitingRoomViewModel` — `WaitingRoomUiState.joinEffect: VideoEffect` replaced by `joinSettings: PublisherSettings`; `joinRoom()` captures mic/camera booleans before `onStop()` destroys the publisher
- `WaitingRoomScreen` / `WaitingRoomRoute` — `navigateToRoom` callback type updated to `(String, PublisherSettings) -> Unit`
- `AppNavHost` — `pendingVideoEffect` side-channel replaced by `pendingPublisherSettings: PublisherSettings`
- `MeetingRoomScreenRoute` — `initialVideoEffect` parameter replaced by `initialPublisherSettings: PublisherSettings`, passed directly to `.publisherSettings()`
- `WaitingRoomViewModelTest` — extended existing join-room test to assert `joinSettings.username`; added new test asserting all four fields when the publisher is already initialised

## Manual verification

1. Build and install a debug build.
2. Enter any room name and tap **Next** to reach the waiting room.
3. In the waiting room:
   - Type a username (e.g. `Alice`).
   - Tap the **microphone** button to mute it.
   - Tap the **camera** button to turn it off.
   - Apply **Blur Low** via the video effects button.
4. Tap **Join**.
5. In the meeting room verify:
   - Publisher tile shows **Alice** as the display name (not empty).
   - Microphone is **muted** on entry (mic button shows muted state).
   - Camera is **off** on entry (local tile shows initials, not a camera feed).
   - Video effect is **Blur Low** once the publisher connects.

> 🤖 This PR was generated with AI assistance.