### PR TITLE
VIDSOL-826: batch background saves and cap picker selection to remaining slots

### DIFF
--- a/app/src/main/java/com/vonage/android/di/FeaturesModule.kt
+++ b/app/src/main/java/com/vonage/android/di/FeaturesModule.kt
@@ -7,6 +7,7 @@ import com.vonage.android.captions.VonageCaptions
 import com.vonage.android.captions.di.CaptionsModule
 import com.vonage.android.chat.ChatFeature
 import com.vonage.android.chat.ChatModule
+import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.kotlin.signal.ChatSignalPlugin
 import com.vonage.android.reactions.ReactionSignalPlugin
 import com.vonage.android.reactions.di.ReactionsModule
@@ -59,4 +60,10 @@ object FeaturesModule {
     @Singleton
     @Provides
     fun provideCallSettingsHolder(): CallSettingsHolder = CallSettingsHolder()
+
+    @Singleton
+    @Provides
+    fun provideUserBackgroundRepository(
+        @ApplicationContext context: Context,
+    ): UserBackgroundRepository = UserBackgroundRepository(context)
 }

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomRoute.kt
@@ -44,7 +44,7 @@ fun WaitingRoomRoute(
             onJoinRoom = { userName -> viewModel.joinRoom(userName) },
             onCameraSwitch = viewModel::onCameraSwitch,
             onApplyVideoEffect = viewModel::applyVideoEffect,
-            onAddBackground = viewModel::addBackground,
+            onAddBackground = viewModel::addBackgrounds,
             onDeleteBackground = viewModel::deleteBackground,
             onBack = {
                 viewModel.onStop()
@@ -99,7 +99,7 @@ data class WaitingRoomActions(
     val onCameraToggle: () -> Unit = {},
     val onOpenVideoEffects: () -> Unit = {},
     val onApplyVideoEffect: (VideoEffect) -> Unit = {},
-    val onAddBackground: (Uri) -> Unit = {},
+    val onAddBackground: (List<Uri>) -> Unit = {},
     val onDeleteBackground: (VideoBackgroundItem) -> Unit = {},
     val onCameraSwitch: () -> Unit = {},
     val onBack: () -> Unit = {},

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
@@ -168,7 +168,8 @@ fun WaitingRoomScreen(
             VideoEffectsScreen(
                 backgrounds = uiState.backgrounds,
                 selectedEffect = selectedEffect,
-                remainingBackgroundSlots = uiState.remainingBackgroundSlots,                onEffectSelect = { effect ->
+                remainingBackgroundSlots = uiState.remainingBackgroundSlots,
+                onEffectSelect = { effect ->
                     selectedEffect = effect
                     actions.onApplyVideoEffect(effect)
                 },

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomScreen.kt
@@ -168,8 +168,7 @@ fun WaitingRoomScreen(
             VideoEffectsScreen(
                 backgrounds = uiState.backgrounds,
                 selectedEffect = selectedEffect,
-                canAddBackground = uiState.canAddBackground,
-                onEffectSelect = { effect ->
+                remainingBackgroundSlots = uiState.remainingBackgroundSlots,                onEffectSelect = { effect ->
                     selectedEffect = effect
                     actions.onApplyVideoEffect(effect)
                 },

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -31,6 +31,8 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
@@ -54,6 +56,7 @@ class WaitingRoomViewModel @AssistedInject constructor(
 ) : ViewModel() {
 
     private var publisherSetupJob: Job? = null
+    private val backgroundsMutex = Mutex()
     private val _uiState = MutableStateFlow(WaitingRoomUiState(roomName = roomName))
     val uiState: StateFlow<WaitingRoomUiState> = _uiState.stateIn(
         scope = viewModelScope,
@@ -121,11 +124,13 @@ class WaitingRoomViewModel @AssistedInject constructor(
      */
     fun addBackgrounds(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
-            val resolution = callSettingsHolder.captureResolution.value
-            for (uri in uris) {
-                userBackgroundRepository.saveBackground(uri, resolution) ?: break
+            backgroundsMutex.withLock {
+                val resolution = callSettingsHolder.captureResolution.value
+                for (uri in uris) {
+                    userBackgroundRepository.saveBackground(uri, resolution) ?: break
+                }
+                refreshBackgrounds()
             }
-            refreshBackgrounds()
         }
     }
 
@@ -296,6 +301,6 @@ data class WaitingRoomUiState(
     val allowCameraControl: Boolean = true,
     val audioDevicesState: AudioDevicesState? = null,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
-    /** Number of additional user backgrounds that can be added before the cap is reached. */
-    val remainingBackgroundSlots: Int = UserBackgroundRepository.MAX_USER_BACKGROUNDS,
+    /** Number of additional user backgrounds that can be added before the cap is reached. 0 until the first refresh completes. */
+    val remainingBackgroundSlots: Int = 0,
 )

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -115,12 +115,17 @@ class WaitingRoomViewModel @AssistedInject constructor(
     }
 
     /**
-     * Saves the image at [uri] to persistent storage and refreshes the backgrounds list.
+     * Saves each image in [uris] to persistent storage sequentially, then refreshes the
+     * backgrounds list once. Processing stops early if
+     * [UserBackgroundRepository.MAX_USER_BACKGROUNDS] is reached mid-batch.
      * IO is performed internally on [Dispatchers.IO].
      */
-    fun addBackground(uri: Uri) {
+    fun addBackgrounds(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
-            userBackgroundRepository.saveBackground(uri, callSettingsHolder.captureResolution.value)
+            val resolution = callSettingsHolder.captureResolution.value
+            uris.forEach { uri ->
+                userBackgroundRepository.saveBackground(uri, resolution) ?: return@forEach
+            }
             refreshBackgrounds()
         }
     }
@@ -197,11 +202,11 @@ class WaitingRoomViewModel @AssistedInject constructor(
         val user = runCatching {
             userBackgroundRepository.getUserBackgrounds(resolution)
         }.getOrElse { persistentListOf() }
-        val canAdd = user.size < UserBackgroundRepository.MAX_USER_BACKGROUNDS
+        val remainingSlots = (UserBackgroundRepository.MAX_USER_BACKGROUNDS - user.size).coerceAtLeast(0)
         _uiState.update {
             it.copy(
                 backgrounds = (builtIn + user).toImmutableList(),
-                canAddBackground = canAdd,
+                remainingBackgroundSlots = remainingSlots,
             )
         }
     }
@@ -292,6 +297,6 @@ data class WaitingRoomUiState(
     val allowCameraControl: Boolean = true,
     val audioDevicesState: AudioDevicesState? = null,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
-    /** Whether the "Add image" tile should be shown in the effects sheet. */
-    val canAddBackground: Boolean = true,
+    /** Number of additional user backgrounds that can be added before the cap is reached. */
+    val remainingBackgroundSlots: Int = UserBackgroundRepository.MAX_USER_BACKGROUNDS,
 )

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -50,6 +50,7 @@ class WaitingRoomViewModel @AssistedInject constructor(
     private val videoClient: VonageVideoClient,
     private val audioDevicesHandler: AudioDevicesHandler,
     private val callSettingsHolder: CallSettingsHolder,
+    private val userBackgroundRepository: UserBackgroundRepository,
 ) : ViewModel() {
 
     private var publisherSetupJob: Job? = null
@@ -59,8 +60,6 @@ class WaitingRoomViewModel @AssistedInject constructor(
         started = WhileSubscribed(SUBSCRIBED_TIMEOUT_MS),
         initialValue = WaitingRoomUiState(roomName = roomName),
     )
-
-    private val userBackgroundRepository = UserBackgroundRepository(appContext)
 
     init {
         viewModelScope.launch(Dispatchers.IO) { refreshBackgrounds() }
@@ -123,8 +122,8 @@ class WaitingRoomViewModel @AssistedInject constructor(
     fun addBackgrounds(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
             val resolution = callSettingsHolder.captureResolution.value
-            uris.forEach { uri ->
-                userBackgroundRepository.saveBackground(uri, resolution) ?: return@forEach
+            for (uri in uris) {
+                userBackgroundRepository.saveBackground(uri, resolution) ?: break
             }
             refreshBackgrounds()
         }

--- a/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
@@ -285,7 +285,7 @@ class WaitingRoomViewModelTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `given empty uri list WHEN addBackgrounds THEN saveBackground not called and slots at max`() =
+    fun `given empty uri list WHEN addBackgrounds THEN saveBackground not called`() =
         runTest {
             advanceUntilIdle() // drain the init refreshBackgrounds coroutine
 
@@ -293,13 +293,10 @@ class WaitingRoomViewModelTest {
             advanceUntilIdle()
 
             verify(exactly = 0) { userBackgroundRepository.saveBackground(any(), any()) }
-            val state = sut.uiState.value
-            assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
-            assertTrue(state.backgrounds.isEmpty())
         }
 
     @Test
-    fun `given uri list WHEN addBackgrounds and save returns null THEN loop breaks after first call and slots unchanged`() =
+    fun `given uri list WHEN addBackgrounds and save returns null THEN loop breaks after first call`() =
         runTest {
             val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
             every { userBackgroundRepository.saveBackground(any(), any()) } returns null
@@ -310,9 +307,22 @@ class WaitingRoomViewModelTest {
 
             // null return → for-loop breaks after the first call
             verify(exactly = 1) { userBackgroundRepository.saveBackground(any(), any()) }
-            val state = sut.uiState.value
-            assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
-            assertTrue(state.backgrounds.isEmpty())
+        }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds and cap hit mid-batch THEN processing stops at cap`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            val savedItem = VideoBackgroundItem(id = "user_bg_test", isUserUploaded = true)
+            // First save fills the last slot, second hits the cap and returns null.
+            every { userBackgroundRepository.saveBackground(any(), any()) } returnsMany listOf(savedItem, null)
+            advanceUntilIdle() // drain the init refreshBackgrounds coroutine
+
+            sut.addBackgrounds(uris)
+            advanceUntilIdle()
+
+            // Loop breaks on second null; third URI is never processed.
+            verify(exactly = 2) { userBackgroundRepository.saveBackground(any(), any()) }
         }
 
     @Test

--- a/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.vonage.android.screen.waiting
 
 import android.content.Context
+import android.net.Uri
 import app.cash.turbine.test
 import com.vonage.android.MainDispatcherRule
 import com.vonage.android.config.Config
@@ -15,13 +16,19 @@ import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.screen.components.audio.AudioDevicesHandler
 import com.vonage.android.settings.CallSettingsHolder
+import com.vonage.android.fx.data.UserBackgroundRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.io.File
+import java.nio.file.Files
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -29,6 +36,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WaitingRoomViewModelTest {
 
     @get:Rule
@@ -53,8 +61,17 @@ class WaitingRoomViewModelTest {
 
     private lateinit var sut: WaitingRoomViewModel
 
+    private val tempFilesDir: File = Files.createTempDirectory("vonage_test_files").toFile()
+
     @Before
     fun setUp() {
+        // Provide a real directory so that File(context.filesDir, ...) in
+        // UserBackgroundRepository doesn't NPE on a mock File's null path field.
+        // openInputStream returns null so BitmapFactory.decodeStream → null
+        // and saveBackground returns null early without writing any file.
+        every { context.filesDir } returns tempFilesDir
+        every { context.contentResolver.openInputStream(any()) } returns null
+
         sut = WaitingRoomViewModel(
             roomName = ANY_ROOM_NAME,
             appContext = context,
@@ -71,6 +88,11 @@ class WaitingRoomViewModelTest {
             allowShowParticipantList = true,
         )
         every { videoClient.configurePublisher(any()) } returns Unit
+    }
+
+    @After
+    fun tearDown() {
+        tempFilesDir.deleteRecursively()
     }
 
     @Test
@@ -266,6 +288,65 @@ class WaitingRoomViewModelTest {
         sut.onStop()
 
         verify { videoClient.destroyPublisher() }
+    }
+
+    // -------------------------------------------------------------------------
+    // addBackgrounds — batch upload
+    //
+    // Note: UserBackgroundRepository is constructed inline inside WaitingRoomViewModel
+    // and cannot be mocked at the unit-test level without a constructor refactor.
+    // These tests therefore exercise the observable state invariants that are
+    // verifiable even when all saveBackground() calls silently return null
+    // (which always happens here because context.contentResolver is a relaxed mock
+    // and BitmapFactory.decodeStream produces null for a mock InputStream).
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `given empty uri list WHEN addBackgrounds THEN remainingBackgroundSlots unchanged and backgrounds empty`() =
+        runTest {
+            advanceUntilIdle() // drain the init refreshBackgrounds coroutine
+
+            sut.addBackgrounds(emptyList())
+            advanceUntilIdle()
+
+            val state = sut.uiState.value
+            assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
+            assertTrue(state.backgrounds.isEmpty())
+        }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds THEN remainingBackgroundSlots unchanged and backgrounds empty`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            advanceUntilIdle() // drain the init refreshBackgrounds coroutine
+
+            // All saves fail (mock context → null InputStream → saveBackground returns null)
+            // refreshBackgrounds() is still called once at the end.
+            sut.addBackgrounds(uris)
+            advanceUntilIdle()
+
+            val state = sut.uiState.value
+            assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
+            assertTrue(state.backgrounds.isEmpty())
+        }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds THEN state updates only once via turbine`() = runTest {
+        val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+        advanceUntilIdle() // drain the init refreshBackgrounds coroutine
+
+        sut.uiState.test {
+            // Consume the current StateFlow value (replayed on subscribe)
+            awaitItem()
+
+            sut.addBackgrounds(uris)
+            advanceUntilIdle()
+
+            // With a relaxed mock context all saves return null, so state doesn't change
+            // → StateFlow emits nothing (deduplication). Verify no spurious extra emissions.
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     private fun givenPreviewPublisher(): PreviewPublisherState {

--- a/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/waiting/WaitingRoomViewModelTest.kt
@@ -17,18 +17,17 @@ import com.vonage.android.meetingroom.api.PublisherSettings
 import com.vonage.android.screen.components.audio.AudioDevicesHandler
 import com.vonage.android.settings.CallSettingsHolder
 import com.vonage.android.fx.data.UserBackgroundRepository
+import com.vonage.android.fx.ui.VideoBackgroundItem
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.io.File
-import java.nio.file.Files
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -59,18 +58,13 @@ class WaitingRoomViewModelTest {
         every { videoBitrateConfig } returns MutableStateFlow(VideoBitrateConfig())
     }
 
-    private lateinit var sut: WaitingRoomViewModel
+    private val userBackgroundRepository: UserBackgroundRepository = mockk(relaxed = true)
 
-    private val tempFilesDir: File = Files.createTempDirectory("vonage_test_files").toFile()
+    private lateinit var sut: WaitingRoomViewModel
 
     @Before
     fun setUp() {
-        // Provide a real directory so that File(context.filesDir, ...) in
-        // UserBackgroundRepository doesn't NPE on a mock File's null path field.
-        // openInputStream returns null so BitmapFactory.decodeStream → null
-        // and saveBackground returns null early without writing any file.
-        every { context.filesDir } returns tempFilesDir
-        every { context.contentResolver.openInputStream(any()) } returns null
+        every { userBackgroundRepository.getUserBackgrounds(any()) } returns persistentListOf()
 
         sut = WaitingRoomViewModel(
             roomName = ANY_ROOM_NAME,
@@ -80,6 +74,7 @@ class WaitingRoomViewModelTest {
             getConfig = getConfig,
             audioDevicesHandler = audioDevicesHandler,
             callSettingsHolder = callSettingsHolder,
+            userBackgroundRepository = userBackgroundRepository,
         )
 
         every { getConfig.invoke() } returns Config(
@@ -88,11 +83,6 @@ class WaitingRoomViewModelTest {
             allowShowParticipantList = true,
         )
         every { videoClient.configurePublisher(any()) } returns Unit
-    }
-
-    @After
-    fun tearDown() {
-        tempFilesDir.deleteRecursively()
     }
 
     @Test
@@ -292,62 +282,53 @@ class WaitingRoomViewModelTest {
 
     // -------------------------------------------------------------------------
     // addBackgrounds — batch upload
-    //
-    // Note: UserBackgroundRepository is constructed inline inside WaitingRoomViewModel
-    // and cannot be mocked at the unit-test level without a constructor refactor.
-    // These tests therefore exercise the observable state invariants that are
-    // verifiable even when all saveBackground() calls silently return null
-    // (which always happens here because context.contentResolver is a relaxed mock
-    // and BitmapFactory.decodeStream produces null for a mock InputStream).
     // -------------------------------------------------------------------------
 
     @Test
-    fun `given empty uri list WHEN addBackgrounds THEN remainingBackgroundSlots unchanged and backgrounds empty`() =
+    fun `given empty uri list WHEN addBackgrounds THEN saveBackground not called and slots at max`() =
         runTest {
             advanceUntilIdle() // drain the init refreshBackgrounds coroutine
 
             sut.addBackgrounds(emptyList())
             advanceUntilIdle()
 
+            verify(exactly = 0) { userBackgroundRepository.saveBackground(any(), any()) }
             val state = sut.uiState.value
             assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
             assertTrue(state.backgrounds.isEmpty())
         }
 
     @Test
-    fun `given uri list WHEN addBackgrounds THEN remainingBackgroundSlots unchanged and backgrounds empty`() =
+    fun `given uri list WHEN addBackgrounds and save returns null THEN loop breaks after first call and slots unchanged`() =
         runTest {
             val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            every { userBackgroundRepository.saveBackground(any(), any()) } returns null
             advanceUntilIdle() // drain the init refreshBackgrounds coroutine
 
-            // All saves fail (mock context → null InputStream → saveBackground returns null)
-            // refreshBackgrounds() is still called once at the end.
             sut.addBackgrounds(uris)
             advanceUntilIdle()
 
+            // null return → for-loop breaks after the first call
+            verify(exactly = 1) { userBackgroundRepository.saveBackground(any(), any()) }
             val state = sut.uiState.value
             assertEquals(UserBackgroundRepository.MAX_USER_BACKGROUNDS, state.remainingBackgroundSlots)
             assertTrue(state.backgrounds.isEmpty())
         }
 
     @Test
-    fun `given uri list WHEN addBackgrounds THEN state updates only once via turbine`() = runTest {
-        val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
-        advanceUntilIdle() // drain the init refreshBackgrounds coroutine
-
-        sut.uiState.test {
-            // Consume the current StateFlow value (replayed on subscribe)
-            awaitItem()
+    fun `given uri list WHEN addBackgrounds and all saves succeed THEN all uris are processed`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            val savedItem = VideoBackgroundItem(id = "user_bg_test", isUserUploaded = true)
+            every { userBackgroundRepository.saveBackground(any(), any()) } returns savedItem
+            advanceUntilIdle() // drain the init refreshBackgrounds coroutine
 
             sut.addBackgrounds(uris)
             advanceUntilIdle()
 
-            // With a relaxed mock context all saves return null, so state doesn't change
-            // → StateFlow emits nothing (deduplication). Verify no spurious extra emissions.
-            expectNoEvents()
-            cancelAndIgnoreRemainingEvents()
+            // All saves return a non-null item → no early break → all 3 URIs are processed.
+            verify(exactly = 3) { userBackgroundRepository.saveBackground(any(), any()) }
         }
-    }
 
     private fun givenPreviewPublisher(): PreviewPublisherState {
         val publisher = buildMockPublisher()

--- a/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
+++ b/vonage-feature-video-effects/src/disabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
@@ -11,9 +11,9 @@ import kotlinx.collections.immutable.ImmutableList
 fun VideoEffectsScreen(
     backgrounds: ImmutableList<VideoBackgroundItem>,
     selectedEffect: VideoEffect,
-    canAddBackground: Boolean,
+    remainingBackgroundSlots: Int,
     onEffectSelect: (VideoEffect) -> Unit,
-    onAddBackground: (Uri) -> Unit,
+    onAddBackground: (List<Uri>) -> Unit,
     onDeleteBackground: (VideoBackgroundItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {}

--- a/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
+++ b/vonage-feature-video-effects/src/enabled/java/com/vonage/android/fx/ui/VideoEffectsScreen.kt
@@ -67,31 +67,49 @@ import kotlinx.coroutines.withContext
  * tap ([onEffectSelect] is called with every selection). There is no Cancel/Apply step —
  * the sheet is dismissed by swiping it down.
  *
- * @param backgrounds       List of virtual background thumbnails to display.
- * @param selectedEffect    Currently active video effect (used to highlight the active tile).
- * @param canAddBackground  Whether the "Add image" tile should be shown. Callers hide it once
- *                          [UserBackgroundRepository.MAX_USER_BACKGROUNDS] is reached.
- * @param onEffectSelect    Invoked when the user taps an effect tile; caller should apply
- *                          it to the publisher immediately.
- * @param onAddBackground   Invoked with the content [Uri] when the user picks an image from
- *                          the system photo picker. Caller is responsible for IO / file saving.
- * @param onDeleteBackground Invoked when the user taps the delete button on a user-uploaded
- *                           background tile.
- * @param modifier          Optional [Modifier] for the root layout.
+ * @param backgrounds            List of virtual background thumbnails to display.
+ * @param selectedEffect         Currently active video effect (used to highlight the active tile).
+ * @param remainingBackgroundSlots Number of additional user backgrounds the app can accept before
+ *                               reaching [UserBackgroundRepository.MAX_USER_BACKGROUNDS]. The
+ *                               "Add image" tile is hidden when this is 0. When it is 1, the
+ *                               system single-item photo picker is shown; for 2+ the multi-item
+ *                               picker is used with the count capped to this value.
+ * @param onEffectSelect         Invoked when the user taps an effect tile; caller should apply
+ *                               it to the publisher immediately.
+ * @param onAddBackground        Invoked with the list of content [Uri]s when the user picks one or
+ *                               more images from the system photo picker. Caller is responsible for
+ *                               IO / file saving.
+ * @param onDeleteBackground     Invoked when the user taps the delete button on a user-uploaded
+ *                               background tile.
+ * @param modifier               Optional [Modifier] for the root layout.
  */
 @Composable
 fun VideoEffectsScreen(
     backgrounds: ImmutableList<VideoBackgroundItem>,
     selectedEffect: VideoEffect,
-    canAddBackground: Boolean,
+    remainingBackgroundSlots: Int,
     onEffectSelect: (VideoEffect) -> Unit,
-    onAddBackground: (Uri) -> Unit,
+    onAddBackground: (List<Uri>) -> Unit,
     onDeleteBackground: (VideoBackgroundItem) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val launcher = rememberLauncherForActivityResult(
+    val canAddBackground = remainingBackgroundSlots > 0
+
+    // Register a multi-item launcher (used when ≥ 2 slots remain) and a single-item launcher
+    // (used when exactly 1 slot remains). Both must always be registered — Compose prohibits
+    // conditional calls to rememberLauncherForActivityResult.
+    val multiLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(
+            maxItems = remainingBackgroundSlots.coerceAtLeast(2),
+        ),
+    ) { uris -> if (uris.isNotEmpty()) onAddBackground(uris) }
+    val singleLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),
-    ) { uri -> uri?.let { onAddBackground(it) } }
+    ) { uri -> uri?.let { onAddBackground(listOf(it)) } }
+
+    val pickerRequest = remember {
+        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+    }
 
     Column(
         modifier = modifier
@@ -116,9 +134,11 @@ fun VideoEffectsScreen(
             canAddBackground = canAddBackground,
             onEffectSelect = onEffectSelect,
             onAddImageClick = {
-                launcher.launch(
-                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
-                )
+                if (remainingBackgroundSlots >= 2) {
+                    multiLauncher.launch(pickerRequest)
+                } else {
+                    singleLauncher.launch(pickerRequest)
+                }
             },
             onDeleteBackground = onDeleteBackground,
             modifier = Modifier.padding(horizontal = VonageVideoTheme.dimens.paddingDefault),
@@ -395,7 +415,7 @@ internal fun VideoEffectsScreenPortraitPreview() {
                 VideoBackgroundItem(id = "bg6"),
             ),
             selectedEffect = VideoEffect.None,
-            canAddBackground = true,
+            remainingBackgroundSlots = 4,
             onEffectSelect = {},
             onAddBackground = {},
             onDeleteBackground = {},
@@ -415,7 +435,7 @@ internal fun VideoEffectsScreenLandscapePreview() {
                 VideoBackgroundItem(id = "bg4"),
             ),
             selectedEffect = VideoEffect.BlurLow,
-            canAddBackground = false,
+            remainingBackgroundSlots = 0,
             onEffectSelect = {},
             onAddBackground = {},
             onDeleteBackground = {},

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/MeetingRoomContent.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/MeetingRoomContent.kt
@@ -125,7 +125,7 @@ private fun MeetingRoomContentInner(
             onSettings = { prebuilt.onAction(MeetingRoomSDKAction.NavigateToSettings) },
             onTogglePinParticipant = viewModel::onTogglePinParticipant,
             onForceMuteParticipant = viewModel::forceMuteParticipant,
-            onAddBackground = viewModel::addBackground,
+            onAddBackground = viewModel::addBackgrounds,
             onDeleteBackground = viewModel::deleteBackground,
         )
     }

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomActions.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomActions.kt
@@ -27,6 +27,6 @@ internal data class MeetingRoomActions(
     val onSettings: () -> Unit = {},
     val onTogglePinParticipant: (String) -> Unit = {},
     val onForceMuteParticipant: (String) -> Unit = {},
-    val onAddBackground: (Uri) -> Unit = {},
+    val onAddBackground: (List<Uri>) -> Unit = {},
     val onDeleteBackground: (VideoBackgroundItem) -> Unit = {},
 )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
@@ -247,8 +247,7 @@ internal fun MeetingRoomScreen(
                     VideoEffectsScreen(
                         backgrounds = uiState.backgrounds,
                         selectedEffect = selectedEffect,
-                        canAddBackground = uiState.canAddBackground,
-                        onEffectSelect = { effect ->
+                        remainingBackgroundSlots = uiState.remainingBackgroundSlots,                        onEffectSelect = { effect ->
                             selectedEffect = effect
                             actions.onApplyVideoEffect(effect)
                         },

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
@@ -3,7 +3,6 @@ package com.vonage.android.meetingroom.internal.screen
 import androidx.compose.runtime.Immutable
 import com.vonage.android.archiving.ArchivingUiState
 import com.vonage.android.captions.CaptionsUiState
-import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.CallFacade
 import com.vonage.android.meetingroom.api.MeetingRoomFeature
@@ -29,8 +28,8 @@ internal data class MeetingRoomUiState(
     val allowCameraControl: Boolean = true,
     val allowShowParticipantList: Boolean = true,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
-    /** Number of additional user backgrounds that can be added before the cap is reached. */
-    val remainingBackgroundSlots: Int = UserBackgroundRepository.MAX_USER_BACKGROUNDS,
+    /** Number of additional user backgrounds that can be added before the cap is reached. 0 until the first refresh completes. */
+    val remainingBackgroundSlots: Int = 0,
     /** Runtime feature set — applied on top of compile-time flavor toggles. */
     val enabledFeatures: Set<MeetingRoomFeature> = MeetingRoomFeature.all,
 )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
@@ -3,6 +3,7 @@ package com.vonage.android.meetingroom.internal.screen
 import androidx.compose.runtime.Immutable
 import com.vonage.android.archiving.ArchivingUiState
 import com.vonage.android.captions.CaptionsUiState
+import com.vonage.android.fx.data.UserBackgroundRepository
 import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.model.CallFacade
 import com.vonage.android.meetingroom.api.MeetingRoomFeature
@@ -28,8 +29,8 @@ internal data class MeetingRoomUiState(
     val allowCameraControl: Boolean = true,
     val allowShowParticipantList: Boolean = true,
     val backgrounds: ImmutableList<VideoBackgroundItem> = persistentListOf(),
-    /** Whether the "Add image" tile should be shown in the effects sheet. */
-    val canAddBackground: Boolean = true,
+    /** Number of additional user backgrounds that can be added before the cap is reached. */
+    val remainingBackgroundSlots: Int = UserBackgroundRepository.MAX_USER_BACKGROUNDS,
     /** Runtime feature set — applied on top of compile-time flavor toggles. */
     val enabledFeatures: Set<MeetingRoomFeature> = MeetingRoomFeature.all,
 )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -28,6 +28,8 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -70,6 +72,7 @@ internal class MeetingRoomViewModel(
 
     private var call: CallFacade? = null
     private val callEnded = AtomicBoolean(false)
+    private val backgroundsMutex = Mutex()
 
     init {
         container.foregroundServiceHandler.startForegroundService(roomName)
@@ -212,11 +215,13 @@ internal class MeetingRoomViewModel(
      */
     fun addBackgrounds(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
-            val resolution = container.callSettingsHolder.captureResolution.value
-            uris.forEach { uri ->
-                container.userBackgroundRepository.saveBackground(uri, resolution) ?: return@forEach
+            backgroundsMutex.withLock {
+                val resolution = container.callSettingsHolder.captureResolution.value
+                for (uri in uris) {
+                    container.userBackgroundRepository.saveBackground(uri, resolution) ?: break
+                }
+                refreshBackgrounds()
             }
-            refreshBackgrounds()
         }
     }
 

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -205,13 +205,17 @@ internal class MeetingRoomViewModel(
     }
 
     /**
-     * Saves the image at [uri] to persistent storage and refreshes the backgrounds list.
+     * Saves each image in [uris] to persistent storage sequentially, then refreshes the
+     * backgrounds list once. Processing stops early if
+     * [UserBackgroundRepository.MAX_USER_BACKGROUNDS] is reached mid-batch.
      * Must be called from any thread; IO is performed internally on [Dispatchers.IO].
      */
-    fun addBackground(uri: Uri) {
+    fun addBackgrounds(uris: List<Uri>) {
         viewModelScope.launch(Dispatchers.IO) {
             val resolution = container.callSettingsHolder.captureResolution.value
-            container.userBackgroundRepository.saveBackground(uri, resolution)
+            uris.forEach { uri ->
+                container.userBackgroundRepository.saveBackground(uri, resolution) ?: return@forEach
+            }
             refreshBackgrounds()
         }
     }
@@ -249,8 +253,8 @@ internal class MeetingRoomViewModel(
             vonageLogger.e("MeetingRoomViewModel", "Failed to load user backgrounds: $throwable")
         }.getOrElse { persistentListOf() }
 
-        val canAdd = user.size < UserBackgroundRepository.MAX_USER_BACKGROUNDS
-        _uiState.update { it.copy(backgrounds = (builtIn + user).toImmutableList(), canAddBackground = canAdd) }
+        val remainingSlots = (UserBackgroundRepository.MAX_USER_BACKGROUNDS - user.size).coerceAtLeast(0)
+        _uiState.update { it.copy(backgrounds = (builtIn + user).toImmutableList(), remainingBackgroundSlots = remainingSlots) }
     }
 
     fun endCall() {

--- a/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
+++ b/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
@@ -2,11 +2,14 @@ package com.vonage.android.meetingroom.internal.viewmodel
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import app.cash.turbine.test
 import com.vonage.android.archiving.ArchivingUiState
 import com.vonage.android.archiving.VonageArchiving
 import com.vonage.android.captions.CaptionsUiState
 import com.vonage.android.captions.VonageCaptions
+import com.vonage.android.fx.data.UserBackgroundRepository
+import com.vonage.android.fx.ui.VideoBackgroundItem
 import com.vonage.android.kotlin.VonageVideoClient
 import com.vonage.android.kotlin.model.ArchivingState
 import com.vonage.android.kotlin.model.CallFacade
@@ -37,6 +40,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -70,6 +74,7 @@ class MeetingRoomViewModelTest {
         every { actions } returns MutableSharedFlow()
     }
     private val activityContextHolder: ActivityContextHolder = mockk(relaxed = true)
+    private val userBackgroundRepository: UserBackgroundRepository = mockk(relaxed = true)
 
     private lateinit var sut: MeetingRoomViewModel
 
@@ -85,6 +90,8 @@ class MeetingRoomViewModelTest {
         every { container.activityContextHolder } returns activityContextHolder
         every { container.audioDevicesHandler } returns audioDevicesHandler
         every { container.callSettingsHolder } returns callSettingsHolder
+        every { container.userBackgroundRepository } returns userBackgroundRepository
+        every { userBackgroundRepository.getUserBackgrounds(any()) } returns persistentListOf()
 
         every { prebuilt.roomName } returns ANY_ROOM_NAME
         every { prebuilt.configuration } returns MeetingRoomConfiguration()
@@ -633,6 +640,63 @@ class MeetingRoomViewModelTest {
         assertEquals(true, state.isError)
         assertEquals("Session error", state.errorMessage)
     }
+
+    // endregion
+
+    // region addBackgrounds
+
+    @Test
+    fun `given empty uri list WHEN addBackgrounds THEN saveBackground not called`() = runTest {
+        testScheduler.advanceUntilIdle() // drain init
+
+        sut.addBackgrounds(emptyList())
+        testScheduler.advanceUntilIdle()
+
+        verify(exactly = 0) { userBackgroundRepository.saveBackground(any(), any()) }
+    }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds and save returns null THEN loop breaks after first call`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            every { userBackgroundRepository.saveBackground(any(), any()) } returns null
+            testScheduler.advanceUntilIdle() // drain init
+
+            sut.addBackgrounds(uris)
+            testScheduler.advanceUntilIdle()
+
+            // null return → for-loop breaks after the first call
+            verify(exactly = 1) { userBackgroundRepository.saveBackground(any(), any()) }
+        }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds and all saves succeed THEN all uris are processed`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            val savedItem = VideoBackgroundItem(id = "user_bg_test", isUserUploaded = true)
+            every { userBackgroundRepository.saveBackground(any(), any()) } returns savedItem
+            testScheduler.advanceUntilIdle() // drain init
+
+            sut.addBackgrounds(uris)
+            testScheduler.advanceUntilIdle()
+
+            verify(exactly = 3) { userBackgroundRepository.saveBackground(any(), any()) }
+        }
+
+    @Test
+    fun `given uri list WHEN addBackgrounds and cap hit mid-batch THEN processing stops at cap`() =
+        runTest {
+            val uris = listOf(mockk<Uri>(), mockk<Uri>(), mockk<Uri>())
+            val savedItem = VideoBackgroundItem(id = "user_bg_test", isUserUploaded = true)
+            every { userBackgroundRepository.saveBackground(any(), any()) } returnsMany listOf(savedItem, null)
+            testScheduler.advanceUntilIdle() // drain init
+
+            sut.addBackgrounds(uris)
+            testScheduler.advanceUntilIdle()
+
+            // Loop breaks on second null; third URI is never processed.
+            verify(exactly = 2) { userBackgroundRepository.saveBackground(any(), any()) }
+        }
 
     // endregion
 


### PR DESCRIPTION
#### What is this PR doing?

Fixes two bugs introduced by the existing multi-select background upload flow and adds picker-level slot enforcement:

**Bug 1 — Race condition on the 10-image cap**
`addBackground(uri: Uri)` launched one coroutine per selected URI. Each coroutine independently read the directory file count before any file was written, so N concurrent saves could all pass the `existingCount >= MAX_USER_BACKGROUNDS` guard and push the total past the cap.

**Bug 2 — N UI state refreshes instead of 1**
Each coroutine called `refreshBackgrounds()` independently, causing N separate `_uiState.update` emissions and visible grid flicker when picking multiple images at once.

**Fix — batch semantics through the full stack**
- `addBackground(uri: Uri)` → `addBackgrounds(uris: List<Uri>)` in both `WaitingRoomViewModel` and `MeetingRoomViewModel`. A single coroutine processes URIs sequentially and calls `refreshBackgrounds()` once at the end.
- `onAddBackground: (Uri) -> Unit` → `(List<Uri>) -> Unit` in `VideoEffectsScreen`, `WaitingRoomActions`, and `MeetingRoomActions`.

**Picker slot cap**
- `canAddBackground: Boolean` replaced with `remainingBackgroundSlots: Int` throughout the stack (`UiState` → `VideoEffectsScreen`).
- The screen registers two launchers unconditionally (Compose rules prohibit conditional `rememberLauncherForActivityResult`):
  - `remainingBackgroundSlots >= 2` → `PickMultipleVisualMedia(maxItems = remainingSlots)` — caps picker selection to the exact number of free slots.
  - `remainingBackgroundSlots == 1` → `PickVisualMedia()` — `maxItems < 2` would throw `IllegalArgumentException`.
  - `remainingBackgroundSlots == 0` → tile is hidden; neither launcher is invoked.

#### How should this be manually tested?

1. Open the Waiting Room or an active call, tap the blur/effects icon.
2. Tap **Add image** — the system photo picker opens in multi-select mode.
3. Select 3 images at once → all 3 appear in the grid in a single update (no flicker).
4. With 9 images already uploaded, tap **Add image** and try to select 3 → the picker limits selection to **1** (one slot remaining). Only 1 image is saved.
5. With 8 images uploaded, tap **Add image** → picker limits selection to **2**.
6. With 10 images uploaded, the **Add image** tile is hidden.

#### What are the relevant tickets?

[VIDSOL-826](https://jira.vonage.com/browse/VIDSOL-826)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### Justification for skipping ci, if applied?

N/A