### PR TITLE
VIDSOL-839: introduce @ExperimentalMeetingRoomApi opt-in annotation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -102,6 +102,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "17"
+        freeCompilerArgs += "-opt-in=com.vonage.android.meetingroom.api.ExperimentalMeetingRoomApi"
     }
     buildFeatures {
         compose = true

--- a/vonage-meeting-room-sample-app/build.gradle.kts
+++ b/vonage-meeting-room-sample-app/build.gradle.kts
@@ -37,6 +37,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "17"
+        freeCompilerArgs += "-opt-in=com.vonage.android.meetingroom.api.ExperimentalMeetingRoomApi"
     }
 }
 

--- a/vonage-meeting-room/build.gradle.kts
+++ b/vonage-meeting-room/build.gradle.kts
@@ -28,6 +28,7 @@ android {
     }
     kotlinOptions {
         jvmTarget = "17"
+        freeCompilerArgs += "-opt-in=com.vonage.android.meetingroom.api.ExperimentalMeetingRoomApi"
     }
 
     buildFeatures {

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/ExperimentalMeetingRoomApi.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/ExperimentalMeetingRoomApi.kt
@@ -1,0 +1,25 @@
+package com.vonage.android.meetingroom.api
+
+/**
+ * Marks the MeetingRoom SDK API as experimental.
+ *
+ * Any API annotated with [ExperimentalMeetingRoomApi] may change or be removed in a future
+ * release without a deprecation cycle. To use these APIs, opt in explicitly:
+ *
+ * - At the call site: `@OptIn(ExperimentalMeetingRoomApi::class)`
+ * - For a whole module: add `-opt-in=com.vonage.android.meetingroom.api.ExperimentalMeetingRoomApi`
+ *   to `freeCompilerArgs` in the module's `kotlinOptions` block.
+ */
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "The MeetingRoom SDK API is experimental and may change without notice. " +
+        "Opt in with @OptIn(ExperimentalMeetingRoomApi::class).",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+)
+@MustBeDocumented
+annotation class ExperimentalMeetingRoomApi

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomBuilder.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomBuilder.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
  * @param baseUrl  Base URL of the Vonage Video backend (e.g. `"https://my-backend.example.com"`).
  * @param roomName Name of the meeting room to join.
  */
+@ExperimentalMeetingRoomApi
 class MeetingRoomBuilder(
     private val baseUrl: String,
     private val roomName: String,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomConfiguration.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomConfiguration.kt
@@ -10,6 +10,7 @@ package com.vonage.android.meetingroom.api
  * @param allowMicrophoneControl   Show a mic on/off toggle in the bottom bar. Default `true`.
  * @param allowShowParticipantList Show the participant list button. Default `true`.
  */
+@ExperimentalMeetingRoomApi
 data class MeetingRoomConfiguration(
     val allowCameraControl: Boolean = true,
     val allowMicrophoneControl: Boolean = true,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomFeature.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomFeature.kt
@@ -10,6 +10,7 @@ package com.vonage.android.meetingroom.api
  * Passing no value to [MeetingRoomBuilder.enabledFeatures] defaults to [MeetingRoomFeature.all],
  * which preserves the same behavior as before the builder API.
  */
+@ExperimentalMeetingRoomApi
 enum class MeetingRoomFeature {
     /** In-call text chat. */
     CHAT,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomPrebuilt.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomPrebuilt.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.asStateFlow
  *   first composed and the call setup begins.
  * @property content     Fully composed meeting room UI. Embed in any Compose hierarchy.
  */
+@ExperimentalMeetingRoomApi
 @Suppress("LongParameterList")
 class MeetingRoomPrebuilt internal constructor(
     internal val baseUrl: String,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomSDKAction.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomSDKAction.kt
@@ -6,6 +6,7 @@ package com.vonage.android.meetingroom.api
  * Register a handler via [MeetingRoomBuilder.onAction]. The host app must handle all cases;
  * alerts (permission prompts, errors) are presented automatically by the SDK.
  */
+@ExperimentalMeetingRoomApi
 sealed class MeetingRoomSDKAction {
 
     /** The call ended — navigate to the goodbye or home screen. */

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomStateHolder.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomStateHolder.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.StateFlow
  * Retrieve an instance via [MeetingRoomPrebuilt.stateHolder]. State is populated once the
  * meeting room composable is first displayed and the call setup begins.
  */
+@ExperimentalMeetingRoomApi
 interface MeetingRoomStateHolder {
     val callState: StateFlow<MeetingRoomCallState>
 }
@@ -21,6 +22,7 @@ interface MeetingRoomStateHolder {
  * @param isLocalCameraEnabled `true` when the local camera is publishing video.
  * @param roomName            Name of the meeting room.
  */
+@ExperimentalMeetingRoomApi
 data class MeetingRoomCallState(
     val isConnected: Boolean = false,
     val participantCount: Int = 0,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomTheme.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/MeetingRoomTheme.kt
@@ -69,6 +69,7 @@ import com.vonage.android.compose.theme.LightWarningHover
  * @param lightColors Color palette used in light mode.
  * @param darkColors  Color palette used in dark mode.
  */
+@ExperimentalMeetingRoomApi
 data class MeetingRoomTheme(
     val lightColors: VonageColors,
     val darkColors: VonageColors,
@@ -84,6 +85,7 @@ data class MeetingRoomTheme(
 }
 
 /** Constructs [VonageColors] from the default Vonage light-mode palette. */
+@ExperimentalMeetingRoomApi
 fun vonageLightColors(): VonageColors = VonageColors(
     primary = LightPrimary,
     onPrimary = LightOnPrimary,
@@ -117,6 +119,7 @@ fun vonageLightColors(): VonageColors = VonageColors(
 )
 
 /** Constructs [VonageColors] from the default Vonage dark-mode palette. */
+@ExperimentalMeetingRoomApi
 fun vonageDarkColors(): VonageColors = VonageColors(
     primary = DarkPrimary,
     onPrimary = DarkOnPrimary,

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/PublisherSettings.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/api/PublisherSettings.kt
@@ -16,6 +16,7 @@ import com.vonage.android.kotlin.model.VideoEffect
  *                            Defaults to [VideoEffect.None]. Pass the effect selected in
  *                            the waiting room to preserve continuity.
  */
+@ExperimentalMeetingRoomApi
 data class PublisherSettings(
     val username: String = "",
     val publishAudio: Boolean = true,


### PR DESCRIPTION
## Summary

- Introduces `@ExperimentalMeetingRoomApi` — a `@RequiresOptIn(ERROR)`-based annotation that marks the entire public API surface of `vonage-meeting-room` as experimental, following the same pattern as Jetpack Compose and the Kotlin stdlib.
- Annotates all 9 top-level declarations in `com.vonage.android.meetingroom.api` (8 classes/interfaces/enums + 2 free functions in `MeetingRoomTheme.kt`).
- Opts in all three consumer modules (`vonage-meeting-room`, `app/`, `vonage-meeting-room-sample-app/`) via a single `freeCompilerArgs` line in each module's `kotlinOptions` block — no per-site `@OptIn` changes needed.

## How it works

Any new host app that takes a dependency on `vonage-meeting-room` and references `MeetingRoomBuilder`, `MeetingRoomPrebuilt`, etc. will get a **compile error** until they explicitly acknowledge the experimental status:

```kotlin
// Option A — call site
@OptIn(ExperimentalMeetingRoomApi::class)
fun startCall() { MeetingRoomBuilder(...).build() }

// Option B — module-wide (recommended for host apps)
// in build.gradle.kts kotlinOptions block:
freeCompilerArgs += "-opt-in=com.vonage.android.meetingroom.api.ExperimentalMeetingRoomApi"
```

## Notes

- `@RequiresOptIn` enforces opt-in for **all** callers, including `internal` code within the same Gradle module. `vonage-meeting-room/build.gradle.kts` therefore also carries the opt-in flag.
- No binary-compatibility validator changes needed — `vonage-meeting-room` does not use that plugin.

---
> ⚠️ This PR was generated with AI assistance.