### PR TITLE
VIDSOL-814: feat: keep captions visible for 2s after final segment

### DIFF
--- a/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/vonage/android/navigation/AppNavHost.kt
@@ -95,7 +95,7 @@ fun AppNavHost(
             val roomName = backStackEntry.toRoute<Goodbye>().roomName
             GoodbyeScreenRoute(
                 roomName = roomName,
-                navigateToMeeting = { roomName -> navController.navigate(Meeting(roomName = roomName)) },
+                navigateToWaiting = { roomName -> navController.navigate(Waiting(roomName = roomName)) },
                 navigateToLanding = {
                     navController.navigate(Landing) {
                         popUpTo(Landing) { inclusive = true }

--- a/app/src/main/java/com/vonage/android/screen/goodbye/GoodbyeScreenRoute.kt
+++ b/app/src/main/java/com/vonage/android/screen/goodbye/GoodbyeScreenRoute.kt
@@ -14,7 +14,7 @@ import com.vonage.android.archiving.Archive
 @Composable
 fun GoodbyeScreenRoute(
     roomName: String,
-    navigateToMeeting: (String) -> Unit,
+    navigateToWaiting: (String) -> Unit,
     navigateToLanding: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: GoodbyeScreenViewModel =
@@ -28,9 +28,9 @@ fun GoodbyeScreenRoute(
 
     val actions = remember {
         GoodbyeScreenActions(
-            onReEnter = { navigateToMeeting(roomName) },
+            onReEnter = { navigateToWaiting(roomName) },
             onGoHome = navigateToLanding,
-            onBack = { navigateToMeeting(roomName) },
+            onBack = { navigateToWaiting(roomName) },
             onDownloadArchive = { archive ->
                 viewModel.downloadArchive(archive)
             }
@@ -38,7 +38,7 @@ fun GoodbyeScreenRoute(
     }
 
     BackHandler {
-        navigateToMeeting(roomName)
+        navigateToWaiting(roomName)
     }
 
     GoodbyeScreen(

--- a/vonage-feature-captions/src/disabled/java/com/vonage/android/captions/DisabledVonageCaptions.kt
+++ b/vonage-feature-captions/src/disabled/java/com/vonage/android/captions/DisabledVonageCaptions.kt
@@ -5,6 +5,8 @@ import com.vonage.android.kotlin.model.CallFacade
 @Suppress("EmptyFunctionBlock")
 class DisabledVonageCaptions : VonageCaptions {
 
+    override val isCapable: Boolean = false
+
     override fun init(
         callFacade: CallFacade,
         roomName: String,

--- a/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
+++ b/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
@@ -17,10 +17,6 @@ class EnabledVonageCaptions(
         this.call = callFacade
         this.roomName = roomName
         this.currentCaptionsId = captionsId
-        
-        if (!captionsId.isNullOrBlank()) {
-            callFacade.enableCaptions()
-        }
     }
 
     override suspend fun enable(): Result<Unit> =

--- a/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
+++ b/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
@@ -15,6 +15,10 @@ class EnabledVonageCaptions(
         this.call = callFacade
         this.roomName = roomName
         this.currentCaptionsId = captionsId
+        
+        if (!captionsId.isNullOrBlank()) {
+            callFacade.enableCaptions()
+        }
     }
 
     override suspend fun enable(): Result<Unit> =

--- a/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
+++ b/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/EnabledVonageCaptions.kt
@@ -7,6 +7,8 @@ class EnabledVonageCaptions(
     private val captionsRepository: CaptionsRepository,
 ) : VonageCaptions {
 
+    override val isCapable: Boolean = true
+
     private var call: CallFacade? = null
     private var currentCaptionsId: String? = null
     private var roomName: String = ""

--- a/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/ui/CaptionsOverlay.kt
+++ b/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/ui/CaptionsOverlay.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -17,6 +18,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.zIndex
+import com.vonage.android.captions.R
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.kotlin.model.CaptionLine
 import kotlinx.collections.immutable.ImmutableList
@@ -51,7 +53,10 @@ fun CaptionsOverlay(
                     Text(
                         text = buildAnnotatedString {
                             withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                append("${line.subscriberName}: ")
+                                val displayName = if (line.isYou) {
+                                    stringResource(R.string.captions_self_name)
+                                } else line.subscriberName
+                                append("$displayName: ")
                             }
                             append(line.text)
                         },
@@ -75,8 +80,8 @@ internal fun CaptionsOverlayPreview() {
         ) {
             CaptionsOverlay(
                 captionLines = persistentListOf(
-                    CaptionLine(streamId = "1", subscriberName = "Alice", text = "Hello, how are you?"),
-                    CaptionLine(streamId = "2", subscriberName = "Bob", text = "I'm doing great, thanks!"),
+                    CaptionLine(streamId = "1", subscriberName = "Alice", isYou = false, text = "Hello, how are you?"),
+                    CaptionLine(streamId = "2", subscriberName = "Bob", isYou = false, text = "I'm doing great, thanks!"),
                 ),
             )
         }

--- a/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/ui/CaptionsOverlay.kt
+++ b/vonage-feature-captions/src/enabled/java/com/vonage/android/captions/ui/CaptionsOverlay.kt
@@ -53,7 +53,7 @@ fun CaptionsOverlay(
                     Text(
                         text = buildAnnotatedString {
                             withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
-                                val displayName = if (line.isYou) {
+                                val displayName = if (line.isMe) {
                                     stringResource(R.string.captions_self_name)
                                 } else line.subscriberName
                                 append("$displayName: ")
@@ -80,8 +80,8 @@ internal fun CaptionsOverlayPreview() {
         ) {
             CaptionsOverlay(
                 captionLines = persistentListOf(
-                    CaptionLine(streamId = "1", subscriberName = "Alice", isYou = false, text = "Hello, how are you?"),
-                    CaptionLine(streamId = "2", subscriberName = "Bob", isYou = false, text = "I'm doing great, thanks!"),
+                    CaptionLine(streamId = "1", subscriberName = "Alice", isMe = false, text = "Hello, how are you?"),
+                    CaptionLine(streamId = "2", subscriberName = "Bob", isMe = false, text = "I'm doing great, thanks!"),
                 ),
             )
         }

--- a/vonage-feature-captions/src/main/java/com/vonage/android/captions/VonageCaptions.kt
+++ b/vonage-feature-captions/src/main/java/com/vonage/android/captions/VonageCaptions.kt
@@ -4,6 +4,9 @@ import com.vonage.android.kotlin.model.CallFacade
 
 interface VonageCaptions {
 
+    /** True when the captions feature is compiled in (captionsEnabled flavor). */
+    val isCapable: Boolean
+
     fun init(callFacade: CallFacade, roomName: String, captionsId: String?)
 
     suspend fun enable(): Result<Unit>

--- a/vonage-feature-captions/src/main/res/values/strings.xml
+++ b/vonage-feature-captions/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="captions_self_name">You</string>
+</resources>

--- a/vonage-feature-captions/src/testEnabled/java/com/vonage/android/captions/EnabledVonageCaptionsTest.kt
+++ b/vonage-feature-captions/src/testEnabled/java/com/vonage/android/captions/EnabledVonageCaptionsTest.kt
@@ -22,6 +22,11 @@ class EnabledVonageCaptionsTest {
     )
 
     @Test
+    fun `isCapable should be true`() {
+        assertTrue(sut.isCapable)
+    }
+
+    @Test
     fun `when enable success then enableCaptions`() = runTest {
         val roomName = "test-room"
         val captionsId = "captions-456"

--- a/vonage-feature-captions/src/testEnabled/java/com/vonage/android/captions/EnabledVonageCaptionsTest.kt
+++ b/vonage-feature-captions/src/testEnabled/java/com/vonage/android/captions/EnabledVonageCaptionsTest.kt
@@ -129,4 +129,32 @@ class EnabledVonageCaptionsTest {
 
         verify { callFacade.enableCaptions() }
     }
+
+    @Test
+    fun `when init with existing captionsId then enableCaptions is called`() = runTest {
+        val roomName = "test-room"
+        val existingCaptionsId = "pre-existing-captions-id"
+
+        sut.init(callFacade, roomName, existingCaptionsId)
+
+        verify { callFacade.enableCaptions() }
+    }
+
+    @Test
+    fun `when init with null captionsId then enableCaptions is not called`() = runTest {
+        val roomName = "test-room"
+
+        sut.init(callFacade, roomName, null)
+
+        verify(exactly = 0) { callFacade.enableCaptions() }
+    }
+
+    @Test
+    fun `when init with blank captionsId then enableCaptions is not called`() = runTest {
+        val roomName = "test-room"
+
+        sut.init(callFacade, roomName, "")
+
+        verify(exactly = 0) { callFacade.enableCaptions() }
+    }
 }

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -161,11 +161,7 @@ internal class MeetingRoomViewModel(
                         roomName = roomName,
                         call = activeCall,
                         archivingUiState = ArchivingUiState.IDLE,
-                        captionsUiState = if (sessionInfo.captionsId.isNullOrBlank()) {
-                            CaptionsUiState.IDLE
-                        } else {
-                            CaptionsUiState.ENABLED
-                        },
+                        captionsUiState = CaptionsUiState.IDLE,
                         isLoading = false,
                         isError = false,
                     )

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -87,6 +87,7 @@ internal class MeetingRoomViewModel(
                 publishVideo = prebuilt.publisherSettings.publishVideo,
                 initialVideoEffect = prebuilt.publisherSettings.initialVideoEffect,
                 cameraIndex = 1, // default to front camera
+                publishCaptions = container.vonageCaptions.isCapable,
             ),
         )
 
@@ -298,6 +299,7 @@ internal class MeetingRoomViewModel(
                                 opusDtxEnabled = holder.opusDtxEnabled.value,
                                 publisherAudioFallback = holder.publisherAudioFallbackEnabled.value,
                                 subscriberAudioFallback = holder.subscriberAudioFallbackEnabled.value,
+                                publishCaptions = container.vonageCaptions.isCapable,
                             ),
                         )
                         vonageLogger.d("MeetingRoomViewModel", "Refresh publisher (${activeCall.publisher.value?.name})")

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
@@ -641,9 +641,6 @@ class Call internal constructor(
             captionsEnabled = enable
             
             if (enable) {
-                // Enable captions on publisher
-                publisher()?.vonagePublisher?.publishCaptions = true
-                
                 // Enable captions on all existing remote subscribers
                 participants.values.filterIsInstance<ParticipantState>()
                     .forEach { participant -> 
@@ -661,9 +658,6 @@ class Call internal constructor(
                     pendingSelfCaptionsSubscription = true
                 }
             } else {
-                // Disable captions on publisher
-                publisher()?.vonagePublisher?.publishCaptions = false
-                
                 // Disable captions on all remote subscribers
                 participants.values.filterIsInstance<ParticipantState>()
                     .forEach { participant -> 

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
@@ -597,16 +597,16 @@ class Call internal constructor(
      * Creates a [VonageCaptionsListener] that upserts a [CaptionLine] into [_captionsStateFlow]
      * and drives the hide-cooldown scheduler.
      *
-     * @param isYou `true` for the local publisher's hidden self-subscriber so the UI can
+     * @param isMe `true` for the local publisher's hidden self-subscriber so the UI can
      *              render the "You" label instead of the stream name.
      */
-    private fun captionsListenerFor(isYou: Boolean): VonageCaptionsListener =
+    private fun captionsListenerFor(isMe: Boolean): VonageCaptionsListener =
         VonageCaptionsListener { name, streamId, text, isFinal ->
             // Cancel any pending hide — the stream is either still active or
             // about to schedule a fresh cooldown.
             captionsHideScheduler.cancel(streamId)
             _captionsStateFlow.update { lines ->
-                val line = CaptionLine(streamId = streamId, subscriberName = name, isYou = isYou, text = text)
+                val line = CaptionLine(streamId = streamId, subscriberName = name, isMe = isMe, text = text)
                 lines.filter { it.streamId != streamId }.plus(line).toImmutableList()
             }
             if (isFinal) {
@@ -614,11 +614,11 @@ class Call internal constructor(
             }
         }
 
-    /** Captions listener for remote participants ([isYou] = `false`). */
-    private val captionsDelegate: VonageCaptionsListener = captionsListenerFor(isYou = false)
+    /** Captions listener for remote participants ([isMe] = `false`). */
+    private val captionsDelegate: VonageCaptionsListener = captionsListenerFor(isMe = false)
 
-    /** Captions listener for the local publisher's hidden self-subscriber ([isYou] = `true`). */
-    private val selfCaptionsDelegate: VonageCaptionsListener = captionsListenerFor(isYou = true)
+    /** Captions listener for the local publisher's hidden self-subscriber ([isMe] = `true`). */
+    private val selfCaptionsDelegate: VonageCaptionsListener = captionsListenerFor(isMe = true)
 
     /**
      * Enables captions.

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
@@ -28,9 +28,11 @@ import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.kotlin.sdk.VonageArchiveListener
 import com.vonage.android.kotlin.sdk.VonageCaptionsListener
 import com.vonage.android.kotlin.sdk.VonageError
+import com.vonage.android.kotlin.sdk.VonagePublisherKitListener
 import com.vonage.android.kotlin.sdk.VonageSession
 import com.vonage.android.kotlin.sdk.VonageSessionListener
 import com.vonage.android.kotlin.sdk.VonageStream
+import com.vonage.android.kotlin.sdk.VonageSubscriber
 import com.vonage.android.kotlin.signal.ChatSignalPlugin
 import com.vonage.android.kotlin.signal.SignalPlugin
 import com.vonage.logger.vonageLogger
@@ -194,6 +196,15 @@ class Call internal constructor(
         }
     }
 
+    /** Hidden subscriber for receiving captions from the publisher's own stream */
+    private var selfCaptionsSubscriber: VonageSubscriber? = null
+    
+    /** Tracks whether captions are currently enabled */
+    private var captionsEnabled: Boolean = false
+    
+    /** Flag for deferred self-captions subscription when publisher stream not yet available */
+    private var pendingSelfCaptionsSubscription: Boolean = false
+
     private val _archivingStateFlow = MutableStateFlow<ArchivingState>(ArchivingState.Idle)
     override val archivingStateFlow: StateFlow<ArchivingState> = _archivingStateFlow
 
@@ -301,7 +312,13 @@ class Call internal constructor(
      * Unpublishes the local stream and disconnects from the session.
      */
     override fun endSession() {
-        publisher()?.vonagePublisher?.let { session.unpublish(it) }
+        // Defensive cleanup of hidden self-captions subscriber
+        cleanupHiddenSelfSubscriber()
+        
+        publisher()?.vonagePublisher?.let { 
+            it.setPublisherListener(null)
+            session.unpublish(it) 
+        }
 
         session.setSessionListener(null)
         session.setSignalListener(null)
@@ -435,6 +452,9 @@ class Call internal constructor(
     override fun refreshPublisher(context: Context) {
         vonageLogger.i("PublisherFactory", "Refresh publisher")
         coroutineScope.launch(Dispatchers.Default) {
+            // Clean up hidden self-subscriber before refreshing publisher
+            cleanupHiddenSelfSubscriber()
+            
             val old = publisher() ?: return@launch
             val wasVideoOn = old.isCameraEnabled.value
             val wasAudioOn = old.isMicEnabled.value
@@ -461,6 +481,29 @@ class Call internal constructor(
             val newPublisher = withContext(Dispatchers.Main) {
                 val publisherState = publisherFactory.createPublisherState(context)
                 session.publish(publisherState.vonagePublisher)
+                
+                // Attach listener to detect when publisher stream becomes available
+                publisherState.vonagePublisher.setPublisherListener(object : VonagePublisherKitListener {
+                    override fun onStreamCreated(stream: VonageStream) {
+                        // Register publisher stream in session's streamMap for self-subscription
+                        session.registerPublisherStream(publisherState.vonagePublisher)
+                        
+                        if (pendingSelfCaptionsSubscription && captionsEnabled) {
+                            createHiddenSelfSubscriber(stream)
+                            pendingSelfCaptionsSubscription = false
+                        }
+                    }
+                    
+                    override fun onStreamDestroyed(stream: VonageStream) {
+                        // Unregister publisher stream from session's streamMap
+                        session.unregisterPublisherStream(publisherState.vonagePublisher)
+                    }
+                    
+                    override fun onError(error: VonageError) {
+                        vonageLogger.e(TAG, "Publisher error: ${error.message}")
+                    }
+                })
+                
                 publisherState
             }
             participants[PUBLISHER_ID] = newPublisher
@@ -478,6 +521,29 @@ class Call internal constructor(
             val newPublisher = withContext(Dispatchers.Main) {
                 val publisherState = publisherFactory.createPublisherState(context)
                 session.publish(publisherState.vonagePublisher)
+                
+                // Attach listener to detect when publisher stream becomes available
+                publisherState.vonagePublisher.setPublisherListener(object : VonagePublisherKitListener {
+                    override fun onStreamCreated(stream: VonageStream) {
+                        // Register publisher stream in session's streamMap for self-subscription
+                        session.registerPublisherStream(publisherState.vonagePublisher)
+                        
+                        if (pendingSelfCaptionsSubscription && captionsEnabled) {
+                            createHiddenSelfSubscriber(stream)
+                            pendingSelfCaptionsSubscription = false
+                        }
+                    }
+                    
+                    override fun onStreamDestroyed(stream: VonageStream) {
+                        // Unregister publisher stream from session's streamMap
+                        session.unregisterPublisherStream(publisherState.vonagePublisher)
+                    }
+                    
+                    override fun onError(error: VonageError) {
+                        vonageLogger.e(TAG, "Publisher error: ${error.message}")
+                    }
+                })
+                
                 publisherState
             }
             participants[PUBLISHER_ID] = newPublisher
@@ -528,22 +594,31 @@ class Call internal constructor(
     //region Captions
 
     /**
-     * Listener for receiving captions from remote participants.
-     * Updates the captions state flow with speaker name and text.
+     * Creates a [VonageCaptionsListener] that upserts a [CaptionLine] into [_captionsStateFlow]
+     * and drives the hide-cooldown scheduler.
+     *
+     * @param isYou `true` for the local publisher's hidden self-subscriber so the UI can
+     *              render the "You" label instead of the stream name.
      */
-    private val captionsDelegate: VonageCaptionsListener =
+    private fun captionsListenerFor(isYou: Boolean): VonageCaptionsListener =
         VonageCaptionsListener { name, streamId, text, isFinal ->
             // Cancel any pending hide — the stream is either still active or
             // about to schedule a fresh cooldown.
             captionsHideScheduler.cancel(streamId)
             _captionsStateFlow.update { lines ->
-                val line = CaptionLine(streamId = streamId, subscriberName = name, text = text)
+                val line = CaptionLine(streamId = streamId, subscriberName = name, isYou = isYou, text = text)
                 lines.filter { it.streamId != streamId }.plus(line).toImmutableList()
             }
             if (isFinal) {
                 captionsHideScheduler.schedule(streamId)
             }
         }
+
+    /** Captions listener for remote participants ([isYou] = `false`). */
+    private val captionsDelegate: VonageCaptionsListener = captionsListenerFor(isYou = false)
+
+    /** Captions listener for the local publisher's hidden self-subscriber ([isYou] = `true`). */
+    private val selfCaptionsDelegate: VonageCaptionsListener = captionsListenerFor(isYou = true)
 
     /**
      * Enables captions.
@@ -563,9 +638,78 @@ class Call internal constructor(
 
     private fun setCaptions(enable: Boolean) {
         coroutineScope.launch {
-            publisher()?.vonagePublisher?.publishCaptions = enable
-            participants.values.filterIsInstance<ParticipantState>()
-                .forEach { participant -> participant.vonageSubscriber.subscribeToCaptions = enable }
+            captionsEnabled = enable
+            
+            if (enable) {
+                // Enable captions on publisher
+                publisher()?.vonagePublisher?.publishCaptions = true
+                
+                // Enable captions on all existing remote subscribers
+                participants.values.filterIsInstance<ParticipantState>()
+                    .forEach { participant -> 
+                        participant.vonageSubscriber.subscribeToCaptions = true 
+                    }
+                
+                // Create hidden self-subscriber
+                val publisherVonagePublisher = publisher()?.vonagePublisher
+                val publisherStream = publisherVonagePublisher?.stream
+                if (publisherStream != null) {
+                    // Ensure publisher stream is registered before subscribing
+                    session.registerPublisherStream(publisherVonagePublisher)
+                    createHiddenSelfSubscriber(publisherStream)
+                } else {
+                    pendingSelfCaptionsSubscription = true
+                }
+            } else {
+                // Disable captions on publisher
+                publisher()?.vonagePublisher?.publishCaptions = false
+                
+                // Disable captions on all remote subscribers
+                participants.values.filterIsInstance<ParticipantState>()
+                    .forEach { participant -> 
+                        participant.vonageSubscriber.subscribeToCaptions = false 
+                    }
+                
+                // Clean up hidden self-subscriber
+                cleanupHiddenSelfSubscriber()
+                pendingSelfCaptionsSubscription = false
+            }
+        }
+    }
+
+    /**
+     * Creates a hidden subscriber for the publisher's own stream to receive self-captions.
+     * Configures the subscriber with audio and video disabled to avoid echo and rendering overhead.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    private fun createHiddenSelfSubscriber(stream: VonageStream) {
+        coroutineScope.launch {
+            try {
+                val subscriber = withContext(Dispatchers.Main) {
+                    session.subscribe(context, stream)
+                }
+                subscriber.subscribeToAudio = false
+                subscriber.subscribeToVideo = false
+                subscriber.subscribeToCaptions = true
+                subscriber.setCaptionsListener(selfCaptionsDelegate)
+                selfCaptionsSubscriber = subscriber
+                vonageLogger.d(TAG, "Created hidden self-captions subscriber for stream ${stream.streamId}")
+            } catch (e: Exception) {
+                vonageLogger.e(TAG, "Failed to create hidden self-captions subscriber", e)
+            }
+        }
+    }
+
+    /**
+     * Cleans up the hidden self-captions subscriber.
+     * Removes listeners and unsubscribes from the session.
+     */
+    private fun cleanupHiddenSelfSubscriber() {
+        selfCaptionsSubscriber?.let { subscriber ->
+            subscriber.setCaptionsListener(null)
+            session.unsubscribe(subscriber)
+            selfCaptionsSubscriber = null
+            vonageLogger.d(TAG, "Cleaned up hidden self-captions subscriber")
         }
     }
     //endregion
@@ -584,6 +728,7 @@ class Call internal constructor(
                 val participant = withContext(Dispatchers.Main) {
                     val subscriber = session.subscribe(context, stream)
                     subscriber.setCaptionsListener(captionsDelegate)
+                    subscriber.subscribeToCaptions = captionsEnabled
                     ParticipantState(vonageSubscriber = subscriber)
                 }
                 launch { participant.setup() }

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
@@ -7,6 +7,7 @@ import com.vonage.android.kotlin.ext.extractSenderName
 import com.vonage.android.kotlin.ext.firstScreenSharing
 import com.vonage.android.kotlin.ext.sorted
 import com.vonage.android.kotlin.internal.ActiveSpeakerTracker
+import com.vonage.android.kotlin.internal.CaptionsHideScheduler
 import com.vonage.android.kotlin.internal.PublisherFactory
 import com.vonage.android.kotlin.model.ArchivingState
 import com.vonage.android.kotlin.model.CallFacade
@@ -184,6 +185,14 @@ class Call internal constructor(
     private val _captionsStateFlow =
         MutableStateFlow<ImmutableList<CaptionLine>>(persistentListOf())
     override val captionsStateFlow: StateFlow<ImmutableList<CaptionLine>> = _captionsStateFlow
+
+    private val captionsHideScheduler = CaptionsHideScheduler(
+        coroutineScope = coroutineScope,
+    ) { streamId ->
+        _captionsStateFlow.update { lines ->
+            lines.filter { it.streamId != streamId }.toImmutableList()
+        }
+    }
 
     private val _archivingStateFlow = MutableStateFlow<ArchivingState>(ArchivingState.Idle)
     override val archivingStateFlow: StateFlow<ArchivingState> = _archivingStateFlow
@@ -524,13 +533,15 @@ class Call internal constructor(
      */
     private val captionsDelegate: VonageCaptionsListener =
         VonageCaptionsListener { name, streamId, text, isFinal ->
+            // Cancel any pending hide — the stream is either still active or
+            // about to schedule a fresh cooldown.
+            captionsHideScheduler.cancel(streamId)
             _captionsStateFlow.update { lines ->
-                if (isFinal) {
-                    lines.filter { it.streamId != streamId }.toImmutableList()
-                } else {
-                    val line = CaptionLine(streamId = streamId, subscriberName = name, text = text)
-                    lines.filter { it.streamId != streamId }.plus(line).toImmutableList()
-                }
+                val line = CaptionLine(streamId = streamId, subscriberName = name, text = text)
+                lines.filter { it.streamId != streamId }.plus(line).toImmutableList()
+            }
+            if (isFinal) {
+                captionsHideScheduler.schedule(streamId)
             }
         }
 
@@ -545,6 +556,8 @@ class Call internal constructor(
      * Disables captions.
      */
     override fun disableCaptions() {
+        captionsHideScheduler.cancelAll()
+        _captionsStateFlow.update { persistentListOf() }
         setCaptions(false)
     }
 

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/CaptionsHideScheduler.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/CaptionsHideScheduler.kt
@@ -1,0 +1,54 @@
+package com.vonage.android.kotlin.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Schedules the delayed removal of caption lines after a speaker's final segment.
+ *
+ * One [Job] is kept per [streamId]. Scheduling the same stream again cancels the
+ * previous job. Calling [cancelAll] is safe to call during session teardown.
+ *
+ * @param coroutineScope Scope used to launch delay jobs (typically Call's own scope).
+ * @param hideDelayMs Time in ms to wait before invoking [onHide]. Defaults to
+ *   [CAPTIONS_HIDE_DELAY_MS]. Override in tests via virtual-time or direct injection.
+ * @param onHide Called with the [streamId] whose line should be removed from state.
+ */
+internal class CaptionsHideScheduler(
+    private val coroutineScope: CoroutineScope,
+    private val hideDelayMs: Long = CAPTIONS_HIDE_DELAY_MS,
+    private val onHide: (streamId: String) -> Unit,
+) {
+    private val jobs = mutableMapOf<String, Job>()
+
+    /** Schedules [onHide] for [streamId] after [hideDelayMs]. Cancels any prior job. */
+    fun schedule(streamId: String) {
+        jobs[streamId]?.cancel()
+        jobs[streamId] = coroutineScope.launch {
+            delay(hideDelayMs)
+            onHide(streamId)
+            jobs.remove(streamId)
+        }
+    }
+
+    /**
+     * Cancels any pending hide job for [streamId].
+     * Call this when a new (non-final) caption arrives for the same stream.
+     */
+    fun cancel(streamId: String) {
+        jobs[streamId]?.cancel()
+        jobs.remove(streamId)
+    }
+
+    /** Cancels all pending jobs. Call this when captions are disabled or session ends. */
+    fun cancelAll() {
+        jobs.values.forEach { it.cancel() }
+        jobs.clear()
+    }
+
+    private companion object {
+        const val CAPTIONS_HIDE_DELAY_MS = 2_000L
+    }
+}

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/CaptionsHideScheduler.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/CaptionsHideScheduler.kt
@@ -3,13 +3,21 @@ package com.vonage.android.kotlin.internal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Schedules the delayed removal of caption lines after a speaker's final segment.
  *
  * One [Job] is kept per [streamId]. Scheduling the same stream again cancels the
  * previous job. Calling [cancelAll] is safe to call during session teardown.
+ *
+ * Thread safety: [schedule], [cancel], and [cancelAll] may be called from any thread
+ * (e.g. the OpenTok SDK callback thread). [ConcurrentHashMap] is used for the jobs map
+ * so that concurrent reads/writes are safe. Each launched job uses [ensureActive] after
+ * the delay to guard against a cancellation that arrived just as the delay completed, and
+ * uses identity-based [ConcurrentHashMap.remove] to avoid evicting a newer job's entry.
  *
  * @param coroutineScope Scope used to launch delay jobs (typically Call's own scope).
  * @param hideDelayMs Time in ms to wait before invoking [onHide]. Defaults to
@@ -21,15 +29,20 @@ internal class CaptionsHideScheduler(
     private val hideDelayMs: Long = CAPTIONS_HIDE_DELAY_MS,
     private val onHide: (streamId: String) -> Unit,
 ) {
-    private val jobs = mutableMapOf<String, Job>()
+    private val jobs = ConcurrentHashMap<String, Job>()
 
     /** Schedules [onHide] for [streamId] after [hideDelayMs]. Cancels any prior job. */
     fun schedule(streamId: String) {
         jobs[streamId]?.cancel()
         jobs[streamId] = coroutineScope.launch {
             delay(hideDelayMs)
+            // Guard against a cancellation that arrived just as the delay completed.
+            ensureActive()
             onHide(streamId)
-            jobs.remove(streamId)
+            // Only remove this stream's entry if it still refers to this exact job.
+            // Prevents a completing job from evicting a newer job that was scheduled
+            // for the same stream while this job was finishing.
+            jobs.remove(streamId, coroutineContext[Job])
         }
     }
 

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/PublisherFactory.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/internal/PublisherFactory.kt
@@ -60,6 +60,7 @@ class PublisherFactory(
 
     fun createPublisherState(context: Context): PublisherState {
         val vonagePublisher = sdkFactory.createPublisher(context, buildVonageConfig())
+        vonagePublisher.publishCaptions = currentConfig?.publishCaptions ?: false
         val effect = currentConfig?.initialVideoEffect ?: VideoEffect.None
         val participant = PublisherState(
             publisherId = PUBLISHER_ID,

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/CallFacade.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/CallFacade.kt
@@ -173,5 +173,6 @@ sealed interface ArchivingState {
 data class CaptionLine(
     val streamId: String,
     val subscriberName: String,
+    val isYou: Boolean,
     val text: String,
 )

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/CallFacade.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/CallFacade.kt
@@ -173,6 +173,6 @@ sealed interface ArchivingState {
 data class CaptionLine(
     val streamId: String,
     val subscriberName: String,
-    val isYou: Boolean,
+    val isMe: Boolean,
     val text: String,
 )

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PublisherConfig.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PublisherConfig.kt
@@ -8,6 +8,8 @@ package com.vonage.android.kotlin.model
  * @property publishAudio Initial audio enabled state
  * @property initialVideoEffect Initial video effect (blur level or background image)
  * @property cameraIndex Initial camera (0 = back, 1 = front)
+ * @property publishCaptions Whether to publish audio for captions transcription. Should be true
+ *   when the captions feature is compiled in (captionsEnabled flavor).
  */
 data class PublisherConfig(
     val name: String,
@@ -28,4 +30,5 @@ data class PublisherConfig(
     val captureResolution: CaptureResolution? = null,
     val preferredVideoCodecOrder: List<VideoCodec>? = null,
     val audioBitrate: Int? = null,
+    val publishCaptions: Boolean = false,
 )

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
@@ -8,6 +8,7 @@ import com.vonage.android.kotlin.model.PublisherState
 import com.vonage.android.kotlin.model.SessionEvent
 import com.vonage.android.kotlin.model.VideoEffect
 import com.vonage.android.kotlin.sdk.VonageArchiveListener
+import com.vonage.android.kotlin.sdk.VonageCaptionsListener
 import com.vonage.android.kotlin.sdk.VonageConnection
 import com.vonage.android.kotlin.sdk.VonageError
 import com.vonage.android.kotlin.sdk.VonagePublisher
@@ -530,6 +531,145 @@ class CallTest {
         val call = createCall()
         assertTrue(call.captionsStateFlow.value.isEmpty())
     }
+
+    @Test
+    fun `captionsDelegate should keep line visible immediately after isFinal`() =
+        runTest(testDispatcher) {
+            val call = createCall()
+            val stream = createVonageStream("stream-1", "Alice")
+            var capturedCaptionsListener: VonageCaptionsListener? = null
+            val mockSubscriber = mockk<VonageSubscriber>(relaxed = true) {
+                every { this@mockk.stream } returns stream
+                every { setCaptionsListener(any()) } answers { capturedCaptionsListener = firstArg() }
+            }
+            every { mockSession.subscribe(any(), any()) } returns mockSubscriber
+
+            call.connect(mockContext).test {
+                triggerConnectedAndWaitForPublisher()
+                awaitItem() // Connected
+
+                capturedSessionListener!!.onStreamReceived(stream)
+                runCurrent()
+                awaitItem() // StreamReceived
+
+                capturedCaptionsListener!!.onCaption("Alice", "stream-1", "Hello!", isFinal = true)
+                runCurrent()
+
+                // Cooldown not elapsed — line must still be visible
+                assertEquals(1, call.captionsStateFlow.value.size)
+                assertEquals("Hello!", call.captionsStateFlow.value.first().text)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `captionsDelegate should hide line after 2s cooldown`() = runTest(testDispatcher) {
+        val call = createCall()
+        val stream = createVonageStream("stream-1", "Alice")
+        var capturedCaptionsListener: VonageCaptionsListener? = null
+        val mockSubscriber = mockk<VonageSubscriber>(relaxed = true) {
+            every { this@mockk.stream } returns stream
+            every { setCaptionsListener(any()) } answers { capturedCaptionsListener = firstArg() }
+        }
+        every { mockSession.subscribe(any(), any()) } returns mockSubscriber
+
+        call.connect(mockContext).test {
+            triggerConnectedAndWaitForPublisher()
+            awaitItem() // Connected
+
+            capturedSessionListener!!.onStreamReceived(stream)
+            runCurrent()
+            awaitItem() // StreamReceived
+
+            capturedCaptionsListener!!.onCaption("Alice", "stream-1", "Hello!", isFinal = true)
+            runCurrent()
+
+            assertEquals(1, call.captionsStateFlow.value.size)
+
+            // Advance past the 2-second cooldown
+            callScheduler.advanceTimeBy(2_001L)
+
+            assertTrue(call.captionsStateFlow.value.isEmpty())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `captionsDelegate should cancel cooldown when new caption arrives for same stream`() =
+        runTest(testDispatcher) {
+            val call = createCall()
+            val stream = createVonageStream("stream-1", "Alice")
+            var capturedCaptionsListener: VonageCaptionsListener? = null
+            val mockSubscriber = mockk<VonageSubscriber>(relaxed = true) {
+                every { this@mockk.stream } returns stream
+                every { setCaptionsListener(any()) } answers { capturedCaptionsListener = firstArg() }
+            }
+            every { mockSession.subscribe(any(), any()) } returns mockSubscriber
+
+            call.connect(mockContext).test {
+                triggerConnectedAndWaitForPublisher()
+                awaitItem() // Connected
+
+                capturedSessionListener!!.onStreamReceived(stream)
+                runCurrent()
+                awaitItem() // StreamReceived
+
+                // Final caption starts cooldown
+                capturedCaptionsListener!!.onCaption("Alice", "stream-1", "Hello!", isFinal = true)
+                runCurrent()
+
+                // New caption arrives before 2s — cancels timer
+                capturedCaptionsListener!!.onCaption("Alice", "stream-1", "World!", isFinal = false)
+                runCurrent()
+
+                // Advance past the original 2-second window
+                callScheduler.advanceTimeBy(2_001L)
+
+                // Line still visible — hide timer was cancelled by the new caption
+                assertEquals(1, call.captionsStateFlow.value.size)
+                assertEquals("World!", call.captionsStateFlow.value.first().text)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `disableCaptions should cancel all pending timers and clear state immediately`() =
+        runTest(testDispatcher) {
+            val call = createCall()
+            val stream = createVonageStream("stream-1", "Alice")
+            var capturedCaptionsListener: VonageCaptionsListener? = null
+            val mockSubscriber = mockk<VonageSubscriber>(relaxed = true) {
+                every { this@mockk.stream } returns stream
+                every { setCaptionsListener(any()) } answers { capturedCaptionsListener = firstArg() }
+            }
+            every { mockSession.subscribe(any(), any()) } returns mockSubscriber
+
+            call.connect(mockContext).test {
+                triggerConnectedAndWaitForPublisher()
+                awaitItem() // Connected
+
+                capturedSessionListener!!.onStreamReceived(stream)
+                runCurrent()
+                awaitItem() // StreamReceived
+
+                capturedCaptionsListener!!.onCaption("Alice", "stream-1", "Hello!", isFinal = true)
+                runCurrent()
+
+                assertEquals(1, call.captionsStateFlow.value.size)
+
+                // Disable clears state immediately without waiting for timers
+                call.disableCaptions()
+                runCurrent()
+
+                assertTrue(call.captionsStateFlow.value.isEmpty())
+
+                // Advance past cooldown — state must remain empty (timer was cancelled)
+                callScheduler.advanceTimeBy(2_001L)
+
+                assertTrue(call.captionsStateFlow.value.isEmpty())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     // endregion
 

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
@@ -495,38 +495,6 @@ class CallTest {
     // region Captions
 
     @Test
-    fun `enableCaptions should set publishCaptions to true on publisher`() = runTest(testDispatcher) {
-        val call = createCall()
-
-        call.connect(mockContext).test {
-            triggerConnectedAndWaitForPublisher()
-            awaitItem()
-
-            call.enableCaptions()
-            runCurrent()
-
-            verify { mockVonagePublisher.publishCaptions = true }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun `disableCaptions should set publishCaptions to false on publisher`() = runTest(testDispatcher) {
-        val call = createCall()
-
-        call.connect(mockContext).test {
-            triggerConnectedAndWaitForPublisher()
-            awaitItem()
-
-            call.disableCaptions()
-            runCurrent()
-
-            verify { mockVonagePublisher.publishCaptions = false }
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `captions state flow should be empty initially`() = runTest(testDispatcher) {
         val call = createCall()
         assertTrue(call.captionsStateFlow.value.isEmpty())

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/internal/CaptionsHideSchedulerTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/internal/CaptionsHideSchedulerTest.kt
@@ -1,0 +1,120 @@
+package com.vonage.android.kotlin.internal
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CaptionsHideSchedulerTest {
+
+    private val testScheduler = TestCoroutineScheduler()
+    private val testDispatcher = StandardTestDispatcher(testScheduler)
+    private val testScope = TestScope(testDispatcher)
+
+    private val hiddenStreams = mutableListOf<String>()
+
+    private fun createScheduler(delayMs: Long = 2_000L) = CaptionsHideScheduler(
+        coroutineScope = testScope,
+        hideDelayMs = delayMs,
+        onHide = { hiddenStreams.add(it) },
+    )
+
+    @Test
+    fun `schedule fires onHide after delay`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+
+        assertTrue(hiddenStreams.isEmpty())
+        advanceTimeBy(2_001L)
+
+        assertEquals(listOf("stream-1"), hiddenStreams)
+    }
+
+    @Test
+    fun `schedule before delay replaces previous job`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+        advanceTimeBy(500L) // halfway through first job
+
+        scheduler.schedule("stream-1") // replaces it
+        advanceTimeBy(2_001L) // full delay from second call
+
+        // onHide fired exactly once
+        assertEquals(1, hiddenStreams.size)
+        assertEquals("stream-1", hiddenStreams.first())
+    }
+
+    @Test
+    fun `cancel prevents onHide from firing`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+        scheduler.cancel("stream-1")
+        advanceTimeBy(2_001L)
+
+        assertTrue(hiddenStreams.isEmpty())
+    }
+
+    @Test
+    fun `cancelAll prevents all pending hides`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+        scheduler.schedule("stream-2")
+        scheduler.cancelAll()
+        advanceTimeBy(2_001L)
+
+        assertTrue(hiddenStreams.isEmpty())
+    }
+
+    @Test
+    fun `schedule after cancel works correctly`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+        scheduler.cancel("stream-1")
+        scheduler.schedule("stream-1")
+        advanceTimeBy(2_001L)
+
+        assertEquals(listOf("stream-1"), hiddenStreams)
+    }
+
+    @Test
+    fun `independent streams have independent timers`() = testScope.runTest {
+        val scheduler = createScheduler()
+
+        scheduler.schedule("stream-1")
+        advanceTimeBy(1_000L) // halfway
+
+        scheduler.schedule("stream-2")
+        advanceTimeBy(1_001L) // stream-1 fires, stream-2 halfway
+
+        assertEquals(listOf("stream-1"), hiddenStreams)
+
+        advanceTimeBy(1_000L) // stream-2 fires
+
+        assertEquals(listOf("stream-1", "stream-2"), hiddenStreams)
+    }
+
+    @Test
+    fun `cancel of unknown stream is safe`() = testScope.runTest {
+        val scheduler = createScheduler()
+        // Should not throw
+        scheduler.cancel("non-existent")
+    }
+
+    @Test
+    fun `cancelAll on empty scheduler is safe`() = testScope.runTest {
+        val scheduler = createScheduler()
+        // Should not throw
+        scheduler.cancelAll()
+    }
+}

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/internal/PublisherFactoryTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/internal/PublisherFactoryTest.kt
@@ -1,0 +1,72 @@
+package com.vonage.android.kotlin.internal
+
+import android.content.Context
+import com.vonage.android.kotlin.model.PublisherConfig
+import com.vonage.android.kotlin.sdk.VonagePublisher
+import com.vonage.android.kotlin.sdk.VonageSdkFactory
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class PublisherFactoryTest {
+
+    private lateinit var mockSdkFactory: VonageSdkFactory
+    private lateinit var mockPublisher: VonagePublisher
+    private lateinit var mockContext: Context
+    private lateinit var publisherFactory: PublisherFactory
+
+    @Before
+    fun setup() {
+        mockContext = mockk(relaxed = true)
+        mockPublisher = mockk(relaxed = true)
+        mockSdkFactory = mockk(relaxed = true) {
+            every { createPublisher(any(), any()) } returns mockPublisher
+            every { getOptimalResolution(any()) } returns com.vonage.android.kotlin.sdk.VonageCaptureResolution.HIGH
+        }
+        publisherFactory = PublisherFactory(sdkFactory = mockSdkFactory)
+    }
+
+    @Test
+    fun `createPublisherState sets publishCaptions to true when config has publishCaptions true`() {
+        publisherFactory.init(
+            PublisherConfig(
+                name = "Test User",
+                publishVideo = true,
+                publishAudio = true,
+                cameraIndex = 1,
+                publishCaptions = true,
+            ),
+        )
+
+        publisherFactory.createPublisherState(mockContext)
+
+        verify { mockPublisher.publishCaptions = true }
+    }
+
+    @Test
+    fun `createPublisherState sets publishCaptions to false when config has publishCaptions false`() {
+        publisherFactory.init(
+            PublisherConfig(
+                name = "Test User",
+                publishVideo = true,
+                publishAudio = true,
+                cameraIndex = 1,
+                publishCaptions = false,
+            ),
+        )
+
+        publisherFactory.createPublisherState(mockContext)
+
+        verify { mockPublisher.publishCaptions = false }
+    }
+
+    @Test
+    fun `createPublisherState sets publishCaptions to false when no config is set`() {
+        // publisherFactory.init() not called — currentConfig is null
+        publisherFactory.createPublisherState(mockContext)
+
+        verify { mockPublisher.publishCaptions = false }
+    }
+}

--- a/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/VonageSessionContract.kt
+++ b/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/VonageSessionContract.kt
@@ -29,6 +29,17 @@ interface VonageSession {
     fun sendSignal(type: String, data: String)
     fun forceMuteStream(stream: VonageStream)
 
+    /**
+     * Registers a publisher's stream for internal tracking.
+     * Used to enable self-subscription for features like self-captions.
+     */
+    fun registerPublisherStream(publisher: VonagePublisher)
+
+    /**
+     * Unregisters a publisher's stream from internal tracking.
+     */
+    fun unregisterPublisherStream(publisher: VonagePublisher)
+
     fun setSessionListener(listener: VonageSessionListener?)
     fun setSignalListener(listener: VonageSignalListener?)
     fun setArchiveListener(listener: VonageArchiveListener?)

--- a/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/VonageSubscriberContract.kt
+++ b/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/VonageSubscriberContract.kt
@@ -14,6 +14,7 @@ interface VonageSubscriber {
     val view: View
 
     var subscribeToVideo: Boolean
+    var subscribeToAudio: Boolean
     var subscribeToCaptions: Boolean
 
     fun setStreamListener(listener: VonageSubscriberStreamListener?)

--- a/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/internal/OpenTokSession.kt
+++ b/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/internal/OpenTokSession.kt
@@ -140,6 +140,27 @@ internal class OpenTokSession(
             }
         })
     }
+
+    /**
+     * Registers a publisher's stream in the internal stream map.
+     * This is needed to allow subscribing to the publisher's own stream for self-captions.
+     */
+    override fun registerPublisherStream(publisher: VonagePublisher) {
+        val real = (publisher as OpenTokPublisher).raw
+        real.stream?.let { stream ->
+            streamMap[stream.streamId] = stream
+        }
+    }
+
+    /**
+     * Unregisters a publisher's stream from the internal stream map.
+     */
+    override fun unregisterPublisherStream(publisher: VonagePublisher) {
+        val real = (publisher as OpenTokPublisher).raw
+        real.stream?.let { stream ->
+            streamMap.remove(stream.streamId)
+        }
+    }
 }
 
 // region Mapping helpers

--- a/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/internal/OpenTokSubscriber.kt
+++ b/vonage-video-sdk/src/main/java/com/vonage/android/kotlin/sdk/internal/OpenTokSubscriber.kt
@@ -31,6 +31,10 @@ internal class OpenTokSubscriber(
         get() = raw.subscribeToVideo
         set(value) { raw.subscribeToVideo = value }
 
+    override var subscribeToAudio: Boolean
+        get() = raw.subscribeToAudio
+        set(value) { raw.subscribeToAudio = value }
+
     override var subscribeToCaptions: Boolean
         get() = raw.subscribeToCaptions
         set(value) { raw.subscribeToCaptions = value }


### PR DESCRIPTION
Captions were disappearing immediately when `isFinal=true` was received from the SDK, giving users no time to read the last sentence.

This PR introduces a 2-second cooldown before a caption line is hidden. Each stream gets an independent timer so speakers don't interfere with each other. Any new caption event for the same stream cancels its pending timer, and disabling captions cancels all timers and clears state immediately.

The cooldown logic is extracted into a new `CaptionsHideScheduler` internal collaborator (mirrors the `ActiveSpeakerTracker` pattern) rather than adding more state to `Call.kt`.