### PR TITLE
VIDSOL-844: Add recording confirmation dialog and participant notification overlay

### DIFF
--- a/.maestro/flows/recording.yaml
+++ b/.maestro/flows/recording.yaml
@@ -15,7 +15,9 @@ appId: ${APP_ID}
 - tapOn:
     id: "room-name-input"
 
-- inputText: "testroom"
+- inputText: "testroomandroid"
+
+- hideKeyboard
 
 - tapOn:
     id: "join-waiting-room-button"
@@ -39,6 +41,8 @@ appId: ${APP_ID}
 
 - inputText: "Test User"
 
+- hideKeyboard
+
 - tapOn:
     id: "join-meeting-button"
 
@@ -61,7 +65,9 @@ appId: ${APP_ID}
     timeout: 3000
 
 # Confirm start recording alert
-- tapOn: "OK"
+- tapOn: "Start Recording"
+
+- pressKey: BACK
 
 - waitForAnimationToEnd:
     timeout: 5000
@@ -87,7 +93,9 @@ appId: ${APP_ID}
     timeout: 3000
 
 # Confirm stop recording alert
-- tapOn: "OK"
+- tapOn: "Stop Recording"
+
+- pressKey: BACK
 
 - waitForAnimationToEnd:
     timeout: 5000
@@ -110,18 +118,18 @@ appId: ${APP_ID}
 
 # Verify archive list is visible on goodbye page
 - assertVisible:
-    id: "archiving-archive-list"
+    id: "goodbye-archives-container"
 
 - takeScreenshot: 04-goodbye-archives
 
 # Wait for archive to process (up to 3 minutes)
 - extendedWaitUntil:
     visible:
-      id: "archiving-download-button"
+      id: "archive-row-download-button"
     timeout: 180000
 
 # Verify download button is available
 - assertVisible:
-    id: "archiving-download-button"
+    id: "archive-row-download-button"
 
 - takeScreenshot: 05-archive-download-ready

--- a/vonage-feature-archiving/src/enabled/java/com/vonage/android/archiving/ui/ArchivesList.kt
+++ b/vonage-feature-archiving/src/enabled/java/com/vonage/android/archiving/ui/ArchivesList.kt
@@ -15,10 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import com.vonage.android.archiving.Archive
 import com.vonage.android.archiving.ArchiveListStyle
 import com.vonage.android.archiving.ArchiveStatus
+import com.vonage.android.archiving.ui.ArchivingTestTags.ARCHIVE_ROW_DOWNLOAD_BUTTON_TAG
 import com.vonage.android.compose.theme.VonageVideoTheme
 import com.vonage.android.compose.vivid.icons.VividIcons
 import com.vonage.android.compose.vivid.icons.solid.Download
@@ -129,7 +131,8 @@ private fun ArchiveRow(
             ArchiveStatus.AVAILABLE -> {
                 Icon(
                     modifier = Modifier
-                        .size(VonageVideoTheme.dimens.iconSizeDefault),
+                        .size(VonageVideoTheme.dimens.iconSizeDefault)
+                        .testTag(ARCHIVE_ROW_DOWNLOAD_BUTTON_TAG),
                     imageVector = VividIcons.Solid.Download,
                     contentDescription = null,
                     tint = VonageVideoTheme.colors.primary,
@@ -154,6 +157,10 @@ private fun ArchiveRow(
             }
         }
     }
+}
+
+object ArchivingTestTags {
+    const val ARCHIVE_ROW_DOWNLOAD_BUTTON_TAG = "archive-row-download-button"
 }
 
 @Suppress("MagicNumber")

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
+import com.vonage.android.archiving.ArchivingUiState
 import com.vonage.android.captions.ui.CaptionsOverlay
 import com.vonage.android.chat.ui.ChatPanel
 import com.vonage.android.compose.components.BasicAlertDialog
@@ -46,6 +47,7 @@ import com.vonage.android.meetingroom.internal.screen.MeetingRoomScreenTestTags.
 import com.vonage.android.meetingroom.internal.screen.audio.AudioDevicesMenu
 import com.vonage.android.meetingroom.internal.screen.components.MeetingRoomContent
 import com.vonage.android.meetingroom.internal.screen.components.MeetingTopBar
+import com.vonage.android.meetingroom.internal.screen.components.RecordingStartedOverlay
 import com.vonage.android.meetingroom.internal.screen.components.SpeakingWhileMutedOverlay
 import com.vonage.android.meetingroom.internal.screen.components.bottombar.BottomBar
 import com.vonage.android.meetingroom.internal.screen.components.bottombar.BottomBarState
@@ -87,6 +89,8 @@ internal fun MeetingRoomScreen(
 ) {
     var showAudioOutputs by remember { mutableStateOf(false) }
     val audioOutputsSheetState = rememberModalBottomSheetState()
+
+    var showRecordingConfirmDialog by remember { mutableStateOf(false) }
 
     var showVideoEffects by remember { mutableStateOf(false) }
     var selectedEffect by remember { mutableStateOf<VideoEffect>(VideoEffect.None) }
@@ -144,6 +148,19 @@ internal fun MeetingRoomScreen(
                 }
             }
 
+            // Wrap actions to show confirmation dialog before starting recording
+            val wrappedActions = remember(actions, uiState.archivingUiState) {
+                actions.copy(
+                    onToggleRecording = { enable ->
+                        if (enable && uiState.archivingUiState == ArchivingUiState.IDLE) {
+                            showRecordingConfirmDialog = true
+                        } else {
+                            actions.onToggleRecording(enable)
+                        }
+                    }
+                )
+            }
+
             Scaffold(
                 modifier = modifier.testTag(MEETING_ROOM_SCREEN_TAG).systemBarsPadding(),
                 topBar = {
@@ -160,7 +177,7 @@ internal fun MeetingRoomScreen(
                     BottomBar(
                         modifier = Modifier.testTag(MEETING_ROOM_BOTTOM_BAR),
                         call = call,
-                        roomActions = actions,
+                        roomActions = wrappedActions,
                         actions = remember(uiState.enabledFeatures) {
                             enabledBottomBarActions(uiState.enabledFeatures)
                         },
@@ -193,6 +210,7 @@ internal fun MeetingRoomScreen(
                             EmojiReactionOverlay(call = call)
                             CaptionsOverlay(captionLines = captionLines)
                             SpeakingWhileMutedOverlay(publisher = publisher)
+                            RecordingStartedOverlay(isRecordingStartedByOthers = uiState.recordingStartedByOthers)
                             // MeetingRoomContent is always visible — the effects sheet is a
                             // ModalBottomSheet that overlays it without disturbing the publisher.
                             MeetingRoomContent(
@@ -281,6 +299,22 @@ internal fun MeetingRoomScreen(
                 actions.onEndCall()
             }
         }
+    }
+
+    // Recording confirmation dialog
+    if (showRecordingConfirmDialog && uiState.archivingUiState == ArchivingUiState.IDLE) {
+        BasicAlertDialog(
+            text = stringResource(R.string.recording_confirm_dialog_message),
+            acceptLabel = stringResource(R.string.recording_confirm_button),
+            cancelLabel = stringResource(R.string.generic_cancel),
+            onAccept = {
+                showRecordingConfirmDialog = false
+                actions.onToggleRecording(true)
+            },
+            onCancel = {
+                showRecordingConfirmDialog = false
+            }
+        )
     }
 }
 

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomScreen.kt
@@ -154,6 +154,8 @@ internal fun MeetingRoomScreen(
                     onToggleRecording = { enable ->
                         if (enable && uiState.archivingUiState == ArchivingUiState.IDLE) {
                             showRecordingConfirmDialog = true
+                        } else if (!enable && uiState.archivingUiState == ArchivingUiState.RECORDING) {
+                            showRecordingConfirmDialog = true
                         } else {
                             actions.onToggleRecording(enable)
                         }
@@ -310,6 +312,20 @@ internal fun MeetingRoomScreen(
             onAccept = {
                 showRecordingConfirmDialog = false
                 actions.onToggleRecording(true)
+            },
+            onCancel = {
+                showRecordingConfirmDialog = false
+            }
+        )
+    }
+    if (showRecordingConfirmDialog && uiState.archivingUiState == ArchivingUiState.RECORDING) {
+        BasicAlertDialog(
+            text = stringResource(R.string.recording_stop_confirm_dialog_message),
+            acceptLabel = stringResource(R.string.recording_stop_confirm_button),
+            cancelLabel = stringResource(R.string.generic_cancel),
+            onAccept = {
+                showRecordingConfirmDialog = false
+                actions.onToggleRecording(false)
             },
             onCancel = {
                 showRecordingConfirmDialog = false

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/MeetingRoomUiState.kt
@@ -37,6 +37,8 @@ internal data class MeetingRoomUiState(
     val remainingBackgroundSlots: Int = UserBackgroundRepository.MAX_USER_BACKGROUNDS,
     /** Runtime feature set — applied on top of compile-time flavor toggles. */
     val enabledFeatures: Set<MeetingRoomFeature> = MeetingRoomFeature.all,
+    /** Flag indicating recording was started by another participant (triggers overlay notification). */
+    val recordingStartedByOthers: Boolean = false,
 )
 
 internal enum class CallLayoutType {

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/components/MeetingTopBar.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/components/MeetingTopBar.kt
@@ -29,6 +29,7 @@ import com.vonage.android.meetingroom.R
 import com.vonage.android.meetingroom.internal.screen.MeetingRoomActions
 import com.vonage.android.meetingroom.internal.screen.audio.AudioDevicesState
 import com.vonage.android.meetingroom.internal.screen.audio.toImageVector
+import com.vonage.android.meetingroom.internal.screen.components.TopBarTestTags.TOP_BAR_ARCHIVING_INDICATOR
 import com.vonage.android.meetingroom.internal.screen.components.TopBarTestTags.TOP_BAR_AUDIO_SELECTOR_ACTION
 import com.vonage.android.meetingroom.internal.screen.components.TopBarTestTags.TOP_BAR_CAMERA_SWITCH_ACTION
 import com.vonage.android.meetingroom.internal.screen.components.TopBarTestTags.TOP_BAR_SHARE_ACTION
@@ -67,6 +68,7 @@ internal fun MeetingTopBar(
                         modifier = Modifier
                             .size(24.dp)
                             .padding(end = 4.dp)
+                            .testTag(TOP_BAR_ARCHIVING_INDICATOR)
                     )
                 }
                 Text(
@@ -130,6 +132,7 @@ object TopBarTestTags {
     const val TOP_BAR_CAMERA_SWITCH_ACTION = "top-bar-camera-switch-action"
     const val TOP_BAR_AUDIO_SELECTOR_ACTION = "top-bar-audio-selector-action"
     const val TOP_BAR_SETTINGS_ACTION = "top-bar-settings-action"
+    const val TOP_BAR_ARCHIVING_INDICATOR = "archiving-recording-indicator"
 }
 
 @PreviewLightDark

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/components/RecordingStartedOverlay.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/screen/components/RecordingStartedOverlay.kt
@@ -1,0 +1,105 @@
+package com.vonage.android.meetingroom.internal.screen.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.zIndex
+import com.vonage.android.compose.theme.VonageVideoTheme
+import com.vonage.android.compose.vivid.icons.VividIcons
+import com.vonage.android.compose.vivid.icons.solid.Rec
+import com.vonage.android.meetingroom.R
+import kotlinx.coroutines.delay
+
+private const val OVERLAY_ZINDEX = 11F
+private const val OVERLAY_DURATION_MS = 4000L
+
+@Composable
+internal fun RecordingStartedOverlay(
+    isRecordingStartedByOthers: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    var showOverlay by remember { mutableStateOf(false) }
+
+    // Show overlay when recording starts, auto-dismiss after duration
+    LaunchedEffect(isRecordingStartedByOthers) {
+        if (isRecordingStartedByOthers) {
+            showOverlay = true
+            delay(OVERLAY_DURATION_MS)
+            showOverlay = false
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .zIndex(OVERLAY_ZINDEX)
+            .fillMaxSize(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        AnimatedVisibility(
+            visible = showOverlay,
+            enter = slideInVertically { -it } + fadeIn(),
+            exit = slideOutVertically { -it } + fadeOut(),
+        ) {
+            RecordingStartedSnackbar()
+        }
+    }
+}
+
+@Composable
+private fun RecordingStartedSnackbar() {
+    Row(
+        modifier = Modifier
+            .background(
+                color = VonageVideoTheme.colors.background.copy(alpha = 0.7f),
+                shape = VonageVideoTheme.shapes.medium,
+            )
+            .padding(
+                horizontal = VonageVideoTheme.dimens.paddingDefault,
+                vertical = VonageVideoTheme.dimens.paddingSmall,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(VonageVideoTheme.dimens.spaceSmall),
+    ) {
+        Icon(
+            imageVector = VividIcons.Solid.Rec,
+            contentDescription = null,
+            tint = Color.Red,
+            modifier = Modifier.size(VonageVideoTheme.dimens.iconSizeSmall),
+        )
+        Text(
+            text = stringResource(R.string.recording_started_notification),
+            color = VonageVideoTheme.colors.textSecondary,
+            style = VonageVideoTheme.typography.bodyExtended,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+internal fun RecordingStartedSnackbarPreview() {
+    VonageVideoTheme {
+        RecordingStartedSnackbar()
+    }
+}

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -367,7 +367,7 @@ internal class MeetingRoomViewModel(
                                 }
                                 // Reset the overlay flag after the overlay duration
                                 if (startedByOthers) {
-                                    delay(5000L)
+                                    delay(RECORDING_OVERLAY_DELAY_MS)
                                     _uiState.update { state ->
                                         state.copy(recordingStartedByOthers = false)
                                     }
@@ -434,5 +434,6 @@ internal class MeetingRoomViewModel(
 
     private companion object {
         const val SUBSCRIBED_TIMEOUT_MS: Long = 5_000
+        const val RECORDING_OVERLAY_DELAY_MS: Long = 5_000
     }
 }

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -367,9 +367,9 @@ internal class MeetingRoomViewModel(
                                 }
                                 // Reset the overlay flag after the overlay duration
                                 if (startedByOthers) {
-                                    delay(RECORDING_OVERLAY_DELAY_MS)
-                                    _uiState.update { state ->
-                                        state.copy(recordingStartedByOthers = false)
+                                    launch {
+                                        delay(RECORDING_OVERLAY_DELAY_MS)
+                                        _uiState.update { state -> state.copy(recordingStartedByOthers = false) }
                                     }
                                 }
                                 // Reset the local flag for next recording

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -27,6 +27,7 @@ import com.vonage.logger.vonageLogger
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -68,6 +69,7 @@ internal class MeetingRoomViewModel(
 
     private var call: CallFacade? = null
     private val callEnded = AtomicBoolean(false)
+    private var localUserStartedRecording = false
 
     init {
         if (prebuilt.foregroundServiceEnabled) {
@@ -324,6 +326,7 @@ internal class MeetingRoomViewModel(
     //region Archiving
     fun archiveCall(enable: Boolean) {
         if (enable) {
+            localUserStartedRecording = true
             _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.STARTING) }
         } else {
             _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.STOPPING) }
@@ -332,10 +335,16 @@ internal class MeetingRoomViewModel(
             if (enable) {
                 container.vonageArchiving.startArchive(roomName)
                     .onSuccess { _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.RECORDING) } }
-                    .onFailure { _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.IDLE) } }
+                    .onFailure {
+                        localUserStartedRecording = false
+                        _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.IDLE) }
+                    }
             } else {
                 container.vonageArchiving.stopArchive(roomName)
-                    .onSuccess { _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.IDLE) } }
+                    .onSuccess {
+                        localUserStartedRecording = false
+                        _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.IDLE) }
+                    }
                     .onFailure { _uiState.update { state -> state.copy(archivingUiState = ArchivingUiState.RECORDING) } }
             }
         }
@@ -348,8 +357,23 @@ internal class MeetingRoomViewModel(
                     .onEach { archivingState ->
                         when (archivingState) {
                             is ArchivingState.Idle -> {}
-                            is ArchivingState.Started -> _uiState.update { state ->
-                                state.copy(archivingUiState = ArchivingUiState.RECORDING)
+                            is ArchivingState.Started -> {
+                                val startedByOthers = !localUserStartedRecording
+                                _uiState.update { state ->
+                                    state.copy(
+                                        archivingUiState = ArchivingUiState.RECORDING,
+                                        recordingStartedByOthers = startedByOthers
+                                    )
+                                }
+                                // Reset the overlay flag after the overlay duration
+                                if (startedByOthers) {
+                                    delay(5000L)
+                                    _uiState.update { state ->
+                                        state.copy(recordingStartedByOthers = false)
+                                    }
+                                }
+                                // Reset the local flag for next recording
+                                localUserStartedRecording = false
                             }
                             is ArchivingState.Stopped -> _uiState.update { state ->
                                 state.copy(archivingUiState = ArchivingUiState.IDLE)

--- a/vonage-meeting-room/src/main/res/values/strings.xml
+++ b/vonage-meeting-room/src/main/res/values/strings.xml
@@ -19,7 +19,9 @@
     <string name="recording_stop_recording">Stop Recording</string>
     <string name="recording_start_recording">Start Recording</string>
     <string name="recording_confirm_dialog_message">Start recording this meeting?</string>
+    <string name="recording_stop_confirm_dialog_message">Stop recording this meeting?</string>
     <string name="recording_confirm_button">Start Recording</string>
+    <string name="recording_stop_confirm_button">Stop Recording</string>
     <string name="recording_started_notification">Recording started</string>
 
     <!-- Screen Share -->

--- a/vonage-meeting-room/src/main/res/values/strings.xml
+++ b/vonage-meeting-room/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <!-- Recordings -->
     <string name="recording_stop_recording">Stop Recording</string>
     <string name="recording_start_recording">Start Recording</string>
+    <string name="recording_confirm_dialog_message">Start recording this meeting?</string>
+    <string name="recording_confirm_button">Start Recording</string>
+    <string name="recording_started_notification">Recording started</string>
 
     <!-- Screen Share -->
     <string name="screen_share_start">Share screen</string>
@@ -33,6 +36,7 @@
 
     <!-- Generic -->
     <string name="generic_retry">Retry</string>
+    <string name="generic_cancel">Cancel</string>
     <string name="change_layout">Change layout</string>
     <string name="chat">Chat</string>
     <string name="speaking_while_muted_message">You are muted. Unmute to speak.</string>

--- a/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
+++ b/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
@@ -441,8 +441,8 @@ class MeetingRoomViewModelTest {
 
             assertEquals(ArchivingUiState.RECORDING, sut.uiState.value.archivingUiState)
             assertEquals(false, sut.uiState.value.recordingStartedByOthers)
+        }
     }
-
     @Test
     fun `given remote participant starts recording then recordingStartedByOthers is true`() = runTest {
         val mockCall = givenMockCall()

--- a/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
+++ b/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
@@ -415,6 +415,61 @@ class MeetingRoomViewModelTest {
         }
     }
 
+    @Test
+    fun `given local user starts recording then recordingStartedByOthers is false`() = runTest {
+        val mockCall = givenMockCall()
+        val archivingStateFlow = MutableSharedFlow<ArchivingState>()
+        every { vonageArchiving.bind(mockCall) } returns archivingStateFlow
+        coEvery { vonageArchiving.startArchive(ANY_ROOM_NAME) } returns success(
+            com.vonage.android.archiving.ArchiveId("archiveId"),
+        )
+
+        sut.uiState.test {
+            awaitItem()
+            sut.setup(context)
+            testScheduler.advanceUntilIdle()
+            awaitItem() // audio devices
+            awaitItem() // connected
+
+            sut.archiveCall(true)
+            skipItems(1) // STARTING
+
+            // Emit the Started event
+            archivingStateFlow.emit(ArchivingState.Started("archiveId"))
+
+            val recordingState = awaitItem()
+            assertEquals(ArchivingUiState.RECORDING, recordingState.archivingUiState)
+            assertEquals(false, recordingState.recordingStartedByOthers)
+        }
+    }
+
+    @Test
+    fun `given remote participant starts recording then recordingStartedByOthers is true`() = runTest {
+        val mockCall = givenMockCall()
+        val archivingStateFlow = MutableSharedFlow<ArchivingState>()
+        every { vonageArchiving.bind(mockCall) } returns archivingStateFlow
+
+        sut.uiState.test {
+            awaitItem()
+            sut.setup(context)
+            testScheduler.advanceUntilIdle()
+            awaitItem() // audio devices
+            awaitItem() // connected
+
+            // Remote participant starts recording (without local archiveCall)
+            archivingStateFlow.emit(ArchivingState.Started("remote-archive-id"))
+
+            val recordingState = awaitItem()
+            assertEquals(ArchivingUiState.RECORDING, recordingState.archivingUiState)
+            assertEquals(true, recordingState.recordingStartedByOthers)
+
+            // Wait for overlay auto-dismiss
+            testScheduler.advanceTimeBy(6000L)
+            val afterTimeout = awaitItem()
+            assertEquals(false, afterTimeout.recordingStartedByOthers)
+        }
+    }
+
     // endregion
 
     // region Screen sharing

--- a/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
+++ b/vonage-meeting-room/src/test/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModelTest.kt
@@ -432,15 +432,15 @@ class MeetingRoomViewModelTest {
             awaitItem() // connected
 
             sut.archiveCall(true)
-            skipItems(1) // STARTING
+            assertEquals(ArchivingUiState.STARTING, awaitItem().archivingUiState)
+            assertEquals(ArchivingUiState.RECORDING, awaitItem().archivingUiState)
 
-            // Emit the Started event
+            // Emit the Started event (may not emit a new uiState item if we're already RECORDING)
             archivingStateFlow.emit(ArchivingState.Started("archiveId"))
+            testScheduler.advanceUntilIdle()
 
-            val recordingState = awaitItem()
-            assertEquals(ArchivingUiState.RECORDING, recordingState.archivingUiState)
-            assertEquals(false, recordingState.recordingStartedByOthers)
-        }
+            assertEquals(ArchivingUiState.RECORDING, sut.uiState.value.archivingUiState)
+            assertEquals(false, sut.uiState.value.recordingStartedByOthers)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add confirmation dialog when user attempts to start recording with message "Start recording this meeting?"
- Add overlay notification that appears to all participants (except the initiator) when recording starts
- Overlay displays "Recording started" with a red recording icon and auto-dismisses after 4 seconds
- Track recording initiator to distinguish between local and remote recording starts

## Changes
- **New file**: `RecordingStartedOverlay.kt` - Overlay component following the `SpeakingWhileMutedOverlay` pattern
- **Modified**: `MeetingRoomViewModel.kt` - Added recording initiator tracking logic with `localUserStartedRecording` flag
- **Modified**: `MeetingRoomUiState.kt` - Added `recordingStartedByOthers` boolean flag
- **Modified**: `MeetingRoomScreen.kt` - Added confirmation dialog and overlay to UI
- **Modified**: `strings.xml` - Added string resources for dialog and overlay messages
- **Tests**: Added 2 new unit tests for recording initiator tracking logic

## Technical Details
- Confirmation dialog intercepts recording action at UI layer (no ViewModel changes for dialog)
- ViewModel tracks whether local user initiated recording vs remote participant
- Overlay uses `LaunchedEffect` with `delay()` for auto-dismiss (4 seconds display, 5 seconds state reset)
- Proper z-index layering with existing overlays (captions, reactions, speaking-while-muted)
- Follows existing codebase patterns and architecture

## Testing
- ✅ Unit tests pass for both local and remote recording scenarios
- ✅ Build successful (app module and meeting-room module)
- ✅ Detekt static analysis passes

## Screenshots/Demo
_Manual testing required to verify visual behavior_

## Checklist
- [x] Code follows project conventions
- [x] Added appropriate tests
- [x] Static analysis passes (detekt)
- [x] No breaking changes to public API
- [x] Documentation updated (inline code comments)