### PR TITLE
VIDSOL-364: fix release camera immediately on end call

### DIFF
--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/Call.kt
@@ -318,7 +318,8 @@ class Call internal constructor(
         
         publisher()?.vonagePublisher?.let { 
             it.setPublisherListener(null)
-            session.unpublish(it) 
+            session.unpublish(it)
+            it.destroy()
         }
 
         session.setSessionListener(null)

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/CallTest.kt
@@ -243,7 +243,7 @@ class CallTest {
     }
 
     @Test
-    fun `endSession should unpublish, disconnect, and clear listeners`() = runTest(testDispatcher) {
+    fun `endSession should unpublish, destroy publisher, disconnect, and clear listeners`() = runTest(testDispatcher) {
         val call = createCall()
 
         call.connect(mockContext).test {
@@ -253,6 +253,7 @@ class CallTest {
             call.endSession()
 
             verify { mockSession.unpublish(mockVonagePublisher) }
+            verify { mockVonagePublisher.destroy() }
             verify { mockSession.setSessionListener(null) }
             verify { mockSession.setSignalListener(null) }
             verify { mockSession.disconnect() }


### PR DESCRIPTION
## Summary

`Call.endSession()` was calling `session.unpublish()` but never `publisher.destroy()`, leaving the OpenTok SDK's camera capturer holding the hardware camera open after the call ended. This caused the camera indicator to linger in the Android status bar for several seconds until GC eventually cleaned it up.

Added `it.destroy()` after `session.unpublish(it)` in `endSession()`, matching the teardown already performed by `PublisherFactory.destroyPublisher()` in the waiting-room path.

## Changes

- `Call.kt` — add `publisher.destroy()` after `session.unpublish()` in `endSession()`
- `CallTest.kt` — extend the `endSession` test to verify `destroy()` is called

## Testing

- Unit tests pass: `./gradlew :vonage-video-core:test`
- Detekt passes (pre-push hook)
- Verified manually: camera indicator disappears immediately after tapping end call

## QA verification
- Create a room or join to an existing one: the device camera led should be on
- Finish the call: the camera led should turn to off (it should take a few seconds depending your OS)
- Try re-joining a call or creating a new one, the behavior should be the same