### PR TITLE
VIDSOL-902: persist call settings across sessions

### DIFF
--- a/app/src/main/java/com/vonage/android/data/storage/DataStoreCallSettingsStorage.kt
+++ b/app/src/main/java/com/vonage/android/data/storage/DataStoreCallSettingsStorage.kt
@@ -1,0 +1,77 @@
+package com.vonage.android.data.storage
+
+import androidx.datastore.preferences.core.edit
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_AUDIO_BITRATE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CAPTURE_FRAME_RATE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CAPTURE_RESOLUTION
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CODEC_ORDER
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_DEGRADATION_PREFERENCE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_OPUS_DTX
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_PUBLISHER_AUDIO_FALLBACK
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_SENDER_STATS
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_SUBSCRIBER_AUDIO_FALLBACK
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_VIDEO_BITRATE_MAX
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_VIDEO_BITRATE_PRESET
+import com.vonage.android.kotlin.model.CaptureFrameRate
+import com.vonage.android.kotlin.model.CaptureResolution
+import com.vonage.android.kotlin.model.DegradationPreference
+import com.vonage.android.kotlin.model.VideoBitrateConfig
+import com.vonage.android.kotlin.model.VideoBitratePreset
+import com.vonage.android.kotlin.model.VideoCodec
+import com.vonage.android.settings.CallSettingsStorage
+import com.vonage.android.settings.PersistedCallSettings
+import javax.inject.Inject
+import kotlinx.coroutines.flow.firstOrNull
+
+class DataStoreCallSettingsStorage @Inject constructor(
+    private val dataStore: GlobalDataStorage,
+) : CallSettingsStorage {
+
+    override suspend fun load(): PersistedCallSettings {
+        val prefs = dataStore.data.firstOrNull() ?: return PersistedCallSettings()
+        return PersistedCallSettings(
+            captureFrameRate = prefs[SETTINGS_CAPTURE_FRAME_RATE]
+                ?.let { CaptureFrameRate.valueOf(it) } ?: CaptureFrameRate.FPS_15,
+            captureResolution = prefs[SETTINGS_CAPTURE_RESOLUTION]
+                ?.let { CaptureResolution.valueOf(it) },
+            preferredVideoCodecOrder = prefs[SETTINGS_CODEC_ORDER]
+                ?.split(",")?.map { VideoCodec.valueOf(it) },
+            audioBitrate = prefs[SETTINGS_AUDIO_BITRATE],
+            opusDtxEnabled = prefs[SETTINGS_OPUS_DTX] ?: true,
+            publisherAudioFallbackEnabled = prefs[SETTINGS_PUBLISHER_AUDIO_FALLBACK] ?: true,
+            subscriberAudioFallbackEnabled = prefs[SETTINGS_SUBSCRIBER_AUDIO_FALLBACK] ?: true,
+            senderStatsEnabled = prefs[SETTINGS_SENDER_STATS] ?: true,
+            videoBitrateConfig = VideoBitrateConfig(
+                preset = prefs[SETTINGS_VIDEO_BITRATE_PRESET]
+                    ?.let { VideoBitratePreset.valueOf(it) } ?: VideoBitratePreset.DEFAULT,
+                maxBitrate = prefs[SETTINGS_VIDEO_BITRATE_MAX],
+            ),
+            degradationPreference = prefs[SETTINGS_DEGRADATION_PREFERENCE]
+                ?.let { DegradationPreference.valueOf(it) } ?: DegradationPreference.NOT_SET,
+        )
+    }
+
+    override suspend fun save(settings: PersistedCallSettings) {
+        val captureResolution = settings.captureResolution
+        val preferredVideoCodecOrder = settings.preferredVideoCodecOrder
+        val audioBitrate = settings.audioBitrate
+        val maxBitrate = settings.videoBitrateConfig.maxBitrate
+        dataStore.edit { prefs ->
+            prefs[SETTINGS_CAPTURE_FRAME_RATE] = settings.captureFrameRate.name
+            if (captureResolution != null) prefs[SETTINGS_CAPTURE_RESOLUTION] = captureResolution.name
+            else prefs.remove(SETTINGS_CAPTURE_RESOLUTION)
+            if (preferredVideoCodecOrder != null) prefs[SETTINGS_CODEC_ORDER] = preferredVideoCodecOrder.joinToString(",") { it.name }
+            else prefs.remove(SETTINGS_CODEC_ORDER)
+            if (audioBitrate != null) prefs[SETTINGS_AUDIO_BITRATE] = audioBitrate
+            else prefs.remove(SETTINGS_AUDIO_BITRATE)
+            prefs[SETTINGS_OPUS_DTX] = settings.opusDtxEnabled
+            prefs[SETTINGS_PUBLISHER_AUDIO_FALLBACK] = settings.publisherAudioFallbackEnabled
+            prefs[SETTINGS_SUBSCRIBER_AUDIO_FALLBACK] = settings.subscriberAudioFallbackEnabled
+            prefs[SETTINGS_SENDER_STATS] = settings.senderStatsEnabled
+            prefs[SETTINGS_VIDEO_BITRATE_PRESET] = settings.videoBitrateConfig.preset.name
+            if (maxBitrate != null) prefs[SETTINGS_VIDEO_BITRATE_MAX] = maxBitrate
+            else prefs.remove(SETTINGS_VIDEO_BITRATE_MAX)
+            prefs[SETTINGS_DEGRADATION_PREFERENCE] = settings.degradationPreference.name
+        }
+    }
+}

--- a/app/src/main/java/com/vonage/android/data/storage/GlobalDataStorage.kt
+++ b/app/src/main/java/com/vonage/android/data/storage/GlobalDataStorage.kt
@@ -3,6 +3,8 @@ package com.vonage.android.data.storage
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -17,5 +19,16 @@ class GlobalDataStorage @Inject constructor(
 ) : DataStore<Preferences> by context.dataStore {
     companion object {
         val USER_NAME = stringPreferencesKey("user_name")
+        val SETTINGS_CAPTURE_FRAME_RATE = stringPreferencesKey("settings_capture_frame_rate")
+        val SETTINGS_CAPTURE_RESOLUTION = stringPreferencesKey("settings_capture_resolution")
+        val SETTINGS_CODEC_ORDER = stringPreferencesKey("settings_codec_order")
+        val SETTINGS_AUDIO_BITRATE = intPreferencesKey("settings_audio_bitrate")
+        val SETTINGS_OPUS_DTX = booleanPreferencesKey("settings_opus_dtx")
+        val SETTINGS_PUBLISHER_AUDIO_FALLBACK = booleanPreferencesKey("settings_publisher_audio_fallback")
+        val SETTINGS_SUBSCRIBER_AUDIO_FALLBACK = booleanPreferencesKey("settings_subscriber_audio_fallback")
+        val SETTINGS_SENDER_STATS = booleanPreferencesKey("settings_sender_stats")
+        val SETTINGS_VIDEO_BITRATE_PRESET = stringPreferencesKey("settings_video_bitrate_preset")
+        val SETTINGS_VIDEO_BITRATE_MAX = intPreferencesKey("settings_video_bitrate_max")
+        val SETTINGS_DEGRADATION_PREFERENCE = stringPreferencesKey("settings_degradation_preference")
     }
 }

--- a/app/src/main/java/com/vonage/android/di/FeaturesModule.kt
+++ b/app/src/main/java/com/vonage/android/di/FeaturesModule.kt
@@ -12,6 +12,7 @@ import com.vonage.android.reactions.ReactionSignalPlugin
 import com.vonage.android.reactions.di.ReactionsModule
 import com.vonage.android.screensharing.VonageScreenSharing
 import com.vonage.android.screensharing.di.ScreenSharingModule
+import com.vonage.android.data.storage.DataStoreCallSettingsStorage
 import com.vonage.android.settings.CallSettingsHolder
 import dagger.Module
 import dagger.Provides
@@ -65,6 +66,7 @@ object FeaturesModule {
 
     @Singleton
     @Provides
-    fun provideCallSettingsHolder(): CallSettingsHolder = CallSettingsHolder()
+    fun provideCallSettingsHolder(storage: DataStoreCallSettingsStorage): CallSettingsHolder =
+        CallSettingsHolder(storage = storage)
 
 }

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -190,7 +190,6 @@ class WaitingRoomViewModel @AssistedInject constructor(
         currentPublisher()?.clean()
         callSettingsHolder.clearCall()
         videoClient.destroyPublisher()
-        viewModelScope.cancel()
     }
 
     /**

--- a/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
+++ b/app/src/main/java/com/vonage/android/screen/waiting/WaitingRoomViewModel.kt
@@ -31,6 +31,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
@@ -69,6 +70,7 @@ class WaitingRoomViewModel @AssistedInject constructor(
     }
 
     fun init(context: Context) {
+        callSettingsHolder.clearCall()
         viewModelScope.launch {
             val config = getConfig()
             val name = userRepository.getUserName()
@@ -178,15 +180,17 @@ class WaitingRoomViewModel @AssistedInject constructor(
                     initialVideoEffect = effect,
                 )
             } ?: PublisherSettings(username = sanitizedUserName)
-            onStop()
             _uiState.update { uiState -> uiState.copy(isSuccess = true, joinSettings = joinSettings) }
+            onStop()
         }
     }
 
     fun onStop() {
         publisherSetupJob?.cancel()
         currentPublisher()?.clean()
+        callSettingsHolder.clearCall()
         videoClient.destroyPublisher()
+        viewModelScope.cancel()
     }
 
     /**

--- a/app/src/test/java/com/vonage/android/data/storage/DataStoreCallSettingsStorageTest.kt
+++ b/app/src/test/java/com/vonage/android/data/storage/DataStoreCallSettingsStorageTest.kt
@@ -1,0 +1,94 @@
+package com.vonage.android.data.storage
+
+import androidx.datastore.preferences.core.preferencesOf
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_AUDIO_BITRATE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CAPTURE_FRAME_RATE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CAPTURE_RESOLUTION
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_CODEC_ORDER
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_DEGRADATION_PREFERENCE
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_OPUS_DTX
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_PUBLISHER_AUDIO_FALLBACK
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_SENDER_STATS
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_SUBSCRIBER_AUDIO_FALLBACK
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_VIDEO_BITRATE_MAX
+import com.vonage.android.data.storage.GlobalDataStorage.Companion.SETTINGS_VIDEO_BITRATE_PRESET
+import com.vonage.android.kotlin.model.CaptureFrameRate
+import com.vonage.android.kotlin.model.CaptureResolution
+import com.vonage.android.kotlin.model.DegradationPreference
+import com.vonage.android.kotlin.model.VideoBitratePreset
+import com.vonage.android.kotlin.model.VideoCodec
+import com.vonage.android.settings.PersistedCallSettings
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DataStoreCallSettingsStorageTest {
+
+    private val dataStore: GlobalDataStorage = mockk(relaxed = true)
+    private val sut = DataStoreCallSettingsStorage(dataStore)
+
+    @Test
+    fun `load on empty store returns defaults`() = runTest {
+        coEvery { dataStore.data } returns flowOf()
+
+        assertEquals(PersistedCallSettings(), sut.load())
+    }
+
+    @Test
+    fun `load maps all stored values to PersistedCallSettings`() = runTest {
+        val prefs = preferencesOf(
+            SETTINGS_CAPTURE_FRAME_RATE to CaptureFrameRate.FPS_30.name,
+            SETTINGS_CAPTURE_RESOLUTION to CaptureResolution.HIGH.name,
+            SETTINGS_CODEC_ORDER to "H264,VP8",
+            SETTINGS_AUDIO_BITRATE to 64_000,
+            SETTINGS_OPUS_DTX to false,
+            SETTINGS_PUBLISHER_AUDIO_FALLBACK to false,
+            SETTINGS_SUBSCRIBER_AUDIO_FALLBACK to false,
+            SETTINGS_SENDER_STATS to false,
+            SETTINGS_VIDEO_BITRATE_PRESET to VideoBitratePreset.CUSTOM.name,
+            SETTINGS_VIDEO_BITRATE_MAX to 3_000,
+            SETTINGS_DEGRADATION_PREFERENCE to DegradationPreference.MAINTAIN_FRAME_RATE.name,
+        )
+        coEvery { dataStore.data } returns flowOf(prefs)
+
+        val result = sut.load()
+
+        assertEquals(CaptureFrameRate.FPS_30, result.captureFrameRate)
+        assertEquals(CaptureResolution.HIGH, result.captureResolution)
+        assertEquals(listOf(VideoCodec.H264, VideoCodec.VP8), result.preferredVideoCodecOrder)
+        assertEquals(64_000, result.audioBitrate)
+        assertEquals(false, result.opusDtxEnabled)
+        assertEquals(false, result.publisherAudioFallbackEnabled)
+        assertEquals(false, result.subscriberAudioFallbackEnabled)
+        assertEquals(false, result.senderStatsEnabled)
+        assertEquals(VideoBitratePreset.CUSTOM, result.videoBitrateConfig.preset)
+        assertEquals(3_000, result.videoBitrateConfig.maxBitrate)
+        assertEquals(DegradationPreference.MAINTAIN_FRAME_RATE, result.degradationPreference)
+    }
+
+    @Test
+    fun `load returns null for absent nullable fields`() = runTest {
+        val prefs = preferencesOf(
+            SETTINGS_CAPTURE_FRAME_RATE to CaptureFrameRate.FPS_15.name,
+        )
+        coEvery { dataStore.data } returns flowOf(prefs)
+
+        val result = sut.load()
+
+        assertNull(result.captureResolution)
+        assertNull(result.preferredVideoCodecOrder)
+        assertNull(result.audioBitrate)
+    }
+
+    @Test
+    fun `save calls dataStore updateData`() = runTest {
+        sut.save(PersistedCallSettings())
+
+        coVerify { dataStore.updateData(any()) }
+    }
+}

--- a/app/src/test/java/com/vonage/android/screen/settings/SettingsActionsTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/settings/SettingsActionsTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -23,7 +24,8 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsActionsTest {
 
-    private val callSettingsHolder = CallSettingsHolder()
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+    private val callSettingsHolder = CallSettingsHolder(scope = testScope)
 
     private fun actionScope(
         initialState: SettingsUiState = SettingsUiState(),

--- a/app/src/test/java/com/vonage/android/screen/settings/SettingsScreenViewModelTest.kt
+++ b/app/src/test/java/com/vonage/android/screen/settings/SettingsScreenViewModelTest.kt
@@ -8,6 +8,9 @@ import com.vonage.android.kotlin.model.DegradationPreference
 import com.vonage.android.kotlin.model.VideoBitrateConfig
 import com.vonage.android.kotlin.model.VideoBitratePreset
 import com.vonage.android.settings.CallSettingsHolder
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -15,12 +18,14 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class SettingsScreenViewModelTest {
 
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
-    private val callSettingsHolder = CallSettingsHolder()
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+    private val callSettingsHolder = CallSettingsHolder(scope = testScope)
 
     private fun sut() = SettingsScreenViewModel(
         appVersion = APP_VERSION,

--- a/vonage-feature-settings/src/enabled/java/com/vonage/android/settings/ui/SettingsScreen.kt
+++ b/vonage-feature-settings/src/enabled/java/com/vonage/android/settings/ui/SettingsScreen.kt
@@ -254,8 +254,8 @@ private fun LazyListScope.settingItem(
 }
 
 @Composable
-private fun disabledHelperText(isCallActive: Boolean): String? =
-    if (isCallActive) stringResource(R.string.settings_disabled_during_call) else null
+private fun nextCallNotice(isCallActive: Boolean): String? =
+    if (isCallActive) stringResource(R.string.settings_next_call_notice) else null
 
 private fun LazyListScope.frameRateItem(uiState: SettingsUiState, actions: SettingsScreenActions) {
     item {
@@ -263,8 +263,7 @@ private fun LazyListScope.frameRateItem(uiState: SettingsUiState, actions: Setti
         FrameRateSelector(
             selected = uiState.captureFrameRate,
             onSelectionChange = actions.onFrameRateChange,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -275,8 +274,7 @@ private fun LazyListScope.resolutionItem(uiState: SettingsUiState, actions: Sett
         ResolutionSelector(
             selected = uiState.captureResolution,
             onSelectionChange = actions.onResolutionChange,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -308,8 +306,7 @@ private fun LazyListScope.codecOrderItem(uiState: SettingsUiState, actions: Sett
         PreferredCodecOrderSelector(
             selectedOrder = uiState.preferredVideoCodecOrder,
             onOrderChange = actions.onPreferredVideoCodecOrderChange,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -322,8 +319,7 @@ private fun LazyListScope.opusDtxItem(uiState: SettingsUiState, actions: Setting
             description = stringResource(R.string.settings_opus_dtx_description),
             isChecked = uiState.opusDtxEnabled,
             onCheckedChange = actions.onOpusDtxToggle,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -334,8 +330,7 @@ private fun LazyListScope.audioBitrateItem(uiState: SettingsUiState, actions: Se
         AudioBitrateSelector(
             audioBitrate = uiState.audioBitrate,
             onAudioBitrateChange = actions.onAudioBitrateChange,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -351,8 +346,7 @@ private fun LazyListScope.publisherAudioFallbackItem(
             description = stringResource(R.string.settings_publisher_audio_fallback_description),
             isChecked = uiState.publisherAudioFallbackEnabled,
             onCheckedChange = actions.onPublisherAudioFallbackToggle,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -368,8 +362,7 @@ private fun LazyListScope.subscriberAudioFallbackItem(
             description = stringResource(R.string.settings_subscriber_audio_fallback_description),
             isChecked = uiState.subscriberAudioFallbackEnabled,
             onCheckedChange = actions.onSubscriberAudioFallbackToggle,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }
@@ -382,8 +375,7 @@ private fun LazyListScope.senderStatsItem(uiState: SettingsUiState, actions: Set
             description = stringResource(R.string.settings_sender_stats_description),
             isChecked = uiState.senderStatsEnabled,
             onCheckedChange = actions.onSenderStatsTrackToggle,
-            enabled = !isCallActive,
-            helperText = disabledHelperText(isCallActive),
+            helperText = nextCallNotice(isCallActive),
         )
     }
 }

--- a/vonage-feature-settings/src/main/java/com/vonage/android/settings/CallSettingsHolder.kt
+++ b/vonage-feature-settings/src/main/java/com/vonage/android/settings/CallSettingsHolder.kt
@@ -8,12 +8,19 @@ import com.vonage.android.kotlin.model.DegradationPreference
 import com.vonage.android.kotlin.model.VideoBitrateConfig
 import com.vonage.android.kotlin.model.VideoBitratePreset
 import com.vonage.android.kotlin.model.VideoCodec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 @Stable
-class CallSettingsHolder {
+class CallSettingsHolder(
+    private val storage: CallSettingsStorage = NoOpCallSettingsStorage(),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+) {
 
     private val _call = MutableStateFlow<CallFacade?>(null)
     val call: StateFlow<CallFacade?> = _call.asStateFlow()
@@ -53,46 +60,72 @@ class CallSettingsHolder {
     private val _audioBitrate = MutableStateFlow<Int?>(null)
     val audioBitrate: StateFlow<Int?> = _audioBitrate.asStateFlow()
 
+    init {
+        scope.launch {
+            val p = storage.load()
+            _captureFrameRate.value = p.captureFrameRate
+            _captureResolution.value = p.captureResolution
+            _preferredVideoCodecOrder.value = p.preferredVideoCodecOrder
+            _audioBitrate.value = p.audioBitrate
+            _opusDtxEnabled.value = p.opusDtxEnabled
+            _publisherAudioFallbackEnabled.value = p.publisherAudioFallbackEnabled
+            _subscriberAudioFallbackEnabled.value = p.subscriberAudioFallbackEnabled
+            _senderStatsEnabled.value = p.senderStatsEnabled
+            _videoBitrateConfig.value = p.videoBitrateConfig
+            _degradationPreference.value = p.degradationPreference
+        }
+    }
+
     fun updateSenderStatsEnabled(enabled: Boolean) {
         _senderStatsEnabled.value = enabled
+        save()
     }
 
     fun updateOpusDtx(enabled: Boolean) {
         _opusDtxEnabled.value = enabled
+        save()
     }
 
     fun updateVideoBitrateConfig(config: VideoBitrateConfig) {
         _videoBitrateConfig.value = config
         _call.value?.setVideoBitrate(config)
+        save()
     }
 
     fun updateDegradationPreference(preference: DegradationPreference) {
         _degradationPreference.value = preference
         _call.value?.setDegradationPreference(preference)
+        save()
     }
 
     fun updateCaptureFrameRate(frameRate: CaptureFrameRate) {
         _captureFrameRate.value = frameRate
+        save()
     }
 
     fun updateCaptureResolution(resolution: CaptureResolution?) {
         _captureResolution.value = resolution
+        save()
     }
 
     fun updatePublisherAudioFallback(enabled: Boolean) {
         _publisherAudioFallbackEnabled.value = enabled
+        save()
     }
 
     fun updateSubscriberAudioFallback(enabled: Boolean) {
         _subscriberAudioFallbackEnabled.value = enabled
+        save()
     }
 
     fun updatePreferredVideoCodecOrder(order: List<VideoCodec>?) {
         _preferredVideoCodecOrder.value = order
+        save()
     }
 
     fun updateAudioBitrate(bitrate: Int?) {
         _audioBitrate.value = bitrate
+        save()
     }
 
     fun clearCall() {
@@ -102,4 +135,21 @@ class CallSettingsHolder {
     fun bind(call: CallFacade) {
         _call.value = call
     }
+
+    private fun save() {
+        scope.launch { storage.save(snapshot()) }
+    }
+
+    private fun snapshot() = PersistedCallSettings(
+        captureFrameRate = _captureFrameRate.value,
+        captureResolution = _captureResolution.value,
+        preferredVideoCodecOrder = _preferredVideoCodecOrder.value,
+        audioBitrate = _audioBitrate.value,
+        opusDtxEnabled = _opusDtxEnabled.value,
+        publisherAudioFallbackEnabled = _publisherAudioFallbackEnabled.value,
+        subscriberAudioFallbackEnabled = _subscriberAudioFallbackEnabled.value,
+        senderStatsEnabled = _senderStatsEnabled.value,
+        videoBitrateConfig = _videoBitrateConfig.value,
+        degradationPreference = _degradationPreference.value,
+    )
 }

--- a/vonage-feature-settings/src/main/java/com/vonage/android/settings/CallSettingsStorage.kt
+++ b/vonage-feature-settings/src/main/java/com/vonage/android/settings/CallSettingsStorage.kt
@@ -1,0 +1,34 @@
+package com.vonage.android.settings
+
+import com.vonage.android.kotlin.model.CaptureFrameRate
+import com.vonage.android.kotlin.model.CaptureResolution
+import com.vonage.android.kotlin.model.DegradationPreference
+import com.vonage.android.kotlin.model.VideoBitrateConfig
+import com.vonage.android.kotlin.model.VideoBitratePreset
+import com.vonage.android.kotlin.model.VideoCodec
+
+data class PersistedCallSettings(
+    val captureFrameRate: CaptureFrameRate = CaptureFrameRate.FPS_15,
+    val captureResolution: CaptureResolution? = null,
+    val preferredVideoCodecOrder: List<VideoCodec>? = null,
+    val audioBitrate: Int? = null,
+    val opusDtxEnabled: Boolean = true,
+    val publisherAudioFallbackEnabled: Boolean = true,
+    val subscriberAudioFallbackEnabled: Boolean = true,
+    val senderStatsEnabled: Boolean = true,
+    val videoBitrateConfig: VideoBitrateConfig = VideoBitrateConfig(
+        preset = VideoBitratePreset.DEFAULT,
+        maxBitrate = VideoBitratePreset.DEFAULT.defaultMaxBitrate,
+    ),
+    val degradationPreference: DegradationPreference = DegradationPreference.NOT_SET,
+)
+
+interface CallSettingsStorage {
+    suspend fun load(): PersistedCallSettings
+    suspend fun save(settings: PersistedCallSettings)
+}
+
+class NoOpCallSettingsStorage : CallSettingsStorage {
+    override suspend fun load() = PersistedCallSettings()
+    override suspend fun save(settings: PersistedCallSettings) = Unit
+}

--- a/vonage-feature-settings/src/main/res/values/strings.xml
+++ b/vonage-feature-settings/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="settings_section_stats">Stats</string>
 
     <string name="settings_close">Close settings</string>
-    <string name="settings_disabled_during_call">Cannot be changed during an active call</string>
+    <string name="settings_next_call_notice">Changes will apply on the next call or when rejoining</string>
 
     <!-- Sender stats -->
     <string name="settings_sender_stats_title">Sender stats</string>

--- a/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/CallSettingsHolderTest.kt
+++ b/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/CallSettingsHolderTest.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -27,7 +28,8 @@ class FakeCallSettingsStorage(
 
 class CallSettingsHolderTest {
 
-    private val sut = CallSettingsHolder()
+    private val testScope = TestScope(UnconfinedTestDispatcher())
+    private val sut = CallSettingsHolder(scope = testScope)
 
     // region defaults
 
@@ -193,6 +195,7 @@ class CallSettingsHolderTest {
     fun `when updateCaptureFrameRate then storage receives save with new value`() = runTest {
         val fake = FakeCallSettingsStorage()
         val holder = CallSettingsHolder(storage = fake, scope = this)
+        advanceUntilIdle() // let init load complete
 
         holder.updateCaptureFrameRate(CaptureFrameRate.FPS_30)
         advanceUntilIdle()
@@ -225,6 +228,7 @@ class CallSettingsHolderTest {
     fun `when updateOpusDtx then storage receives save with new value`() = runTest {
         val fake = FakeCallSettingsStorage()
         val holder = CallSettingsHolder(storage = fake, scope = this)
+        advanceUntilIdle() // let init load complete
 
         holder.updateOpusDtx(false)
         advanceUntilIdle()

--- a/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/CallSettingsHolderTest.kt
+++ b/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/CallSettingsHolderTest.kt
@@ -8,10 +8,22 @@ import com.vonage.android.kotlin.model.VideoBitrateConfig
 import com.vonage.android.kotlin.model.VideoBitratePreset
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+class FakeCallSettingsStorage(
+    private val initial: PersistedCallSettings = PersistedCallSettings(),
+) : CallSettingsStorage {
+    var saved: PersistedCallSettings? = null
+    override suspend fun load() = initial
+    override suspend fun save(settings: PersistedCallSettings) { saved = settings }
+}
 
 class CallSettingsHolderTest {
 
@@ -171,6 +183,53 @@ class CallSettingsHolderTest {
         assertEquals(CaptureResolution.HIGH_1080P, sut.captureResolution.value)
         assertEquals(false, sut.publisherAudioFallbackEnabled.value)
         assertEquals(false, sut.subscriberAudioFallbackEnabled.value)
+    }
+
+    // endregion
+
+    // region storage
+
+    @Test
+    fun `when updateCaptureFrameRate then storage receives save with new value`() = runTest {
+        val fake = FakeCallSettingsStorage()
+        val holder = CallSettingsHolder(storage = fake, scope = this)
+
+        holder.updateCaptureFrameRate(CaptureFrameRate.FPS_30)
+        advanceUntilIdle()
+
+        assertEquals(CaptureFrameRate.FPS_30, fake.saved?.captureFrameRate)
+    }
+
+    @Test
+    fun `given storage with persisted values then holder restores them on init`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val testScope = TestScope(dispatcher)
+        val persisted = PersistedCallSettings(
+            captureFrameRate = CaptureFrameRate.FPS_30,
+            captureResolution = CaptureResolution.HIGH,
+            opusDtxEnabled = false,
+            senderStatsEnabled = false,
+        )
+        val fake = FakeCallSettingsStorage(initial = persisted)
+
+        val holder = CallSettingsHolder(storage = fake, scope = testScope)
+        testScope.advanceUntilIdle()
+
+        assertEquals(CaptureFrameRate.FPS_30, holder.captureFrameRate.value)
+        assertEquals(CaptureResolution.HIGH, holder.captureResolution.value)
+        assertEquals(false, holder.opusDtxEnabled.value)
+        assertEquals(false, holder.senderStatsEnabled.value)
+    }
+
+    @Test
+    fun `when updateOpusDtx then storage receives save with new value`() = runTest {
+        val fake = FakeCallSettingsStorage()
+        val holder = CallSettingsHolder(storage = fake, scope = this)
+
+        holder.updateOpusDtx(false)
+        advanceUntilIdle()
+
+        assertEquals(false, fake.saved?.opusDtxEnabled)
     }
 
     // endregion

--- a/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/NoOpCallSettingsStorageTest.kt
+++ b/vonage-feature-settings/src/testEnabled/java/com/vonage/android/settings/NoOpCallSettingsStorageTest.kt
@@ -1,0 +1,20 @@
+package com.vonage.android.settings
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NoOpCallSettingsStorageTest {
+
+    private val sut = NoOpCallSettingsStorage()
+
+    @Test
+    fun `load returns default PersistedCallSettings`() = runTest {
+        assertEquals(PersistedCallSettings(), sut.load())
+    }
+
+    @Test
+    fun `save completes without error`() = runTest {
+        sut.save(PersistedCallSettings())
+    }
+}

--- a/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
+++ b/vonage-meeting-room/src/main/java/com/vonage/android/meetingroom/internal/viewmodel/MeetingRoomViewModel.kt
@@ -93,6 +93,15 @@ internal class MeetingRoomViewModel(
                 initialVideoEffect = prebuilt.publisherSettings.initialVideoEffect,
                 cameraIndex = 1, // default to front camera
                 publishCaptions = container.vonageCaptions.isCapable,
+                senderStatsTrack = container.callSettingsHolder.senderStatsEnabled.value,
+                opusDtxEnabled = container.callSettingsHolder.opusDtxEnabled.value,
+                publisherAudioFallback = container.callSettingsHolder.publisherAudioFallbackEnabled.value,
+                subscriberAudioFallback = container.callSettingsHolder.subscriberAudioFallbackEnabled.value,
+                videoBitrateConfig = container.callSettingsHolder.videoBitrateConfig.value,
+                captureFrameRate = container.callSettingsHolder.captureFrameRate.value,
+                captureResolution = container.callSettingsHolder.captureResolution.value,
+                preferredVideoCodecOrder = container.callSettingsHolder.preferredVideoCodecOrder.value,
+                audioBitrate = container.callSettingsHolder.audioBitrate.value,
             ),
         )
 


### PR DESCRIPTION
## Summary

Saves all 10 call settings to DataStore so they are restored the next time the user opens the app, without resetting to defaults on each launch.

### Changes

**`vonage-feature-settings`**
- Add `PersistedCallSettings` data class and `CallSettingsStorage` interface (+ `NoOpCallSettingsStorage` default)
- `CallSettingsHolder` now accepts a `CallSettingsStorage` dependency; loads persisted values on init and saves on every `update*` call
- Settings screen: non-runtime settings are now always interactive during a call — replaced the disabled state with an informational notice: "Changes will apply on the next call or when rejoining"

**`app`**
- Add `DataStoreCallSettingsStorage` backed by `GlobalDataStorage` (DataStore)
- Add 11 preference keys to `GlobalDataStorage.Companion`
- Wire `DataStoreCallSettingsStorage` into `FeaturesModule.provideCallSettingsHolder`
- `WaitingRoomViewModel.init()` calls `clearCall()` to prevent stale `CallFacade` binding from a previous session

**`vonage-meeting-room`**
- `MeetingRoomViewModel.setup()` now reads all `callSettingsHolder` values when constructing the `PublisherConfig`, so settings such as `captureFrameRate`, `captureResolution`, codec order, audio bitrate, and fallback flags are correctly applied when the call starts

### Tested
- Unit tests: `CallSettingsHolderTest`, `NoOpCallSettingsStorageTest`, `DataStoreCallSettingsStorageTest`
- Detekt passing