### PR TITLE
VIDSOL-1003: bump version to 1.2.1

### DIFF
--- a/.github/workflows/publish-play-store.yml
+++ b/.github/workflows/publish-play-store.yml
@@ -63,8 +63,8 @@ jobs:
 
       - name: Set version from GitHub run number
         run: |
-          VERSION_CODE=$((1000100 + $GITHUB_RUN_NUMBER))
-          VERSION_NAME="1.1.0-build${GITHUB_RUN_NUMBER}"
+          VERSION_CODE=$((1000201 + $GITHUB_RUN_NUMBER))
+          VERSION_NAME="1.2.1-build${GITHUB_RUN_NUMBER}"
           sed -i "s/versionCode = [0-9]\+/versionCode = $VERSION_CODE/" app/build.gradle.kts
           sed -i "s/versionName = \".*\"/versionName = \"$VERSION_NAME\"/" app/build.gradle.kts
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         targetSdk = 36
         // NOTE: The following versionCode and versionName are placeholders.
         // Actual values are set dynamically by the GitHub Actions workflow during CI/CD.
-        versionCode = 110
-        versionName = "1.1.0"
+        versionCode = 121
+        versionName = "1.2.1"
 
         testInstrumentationRunner = "com.vonage.android.HiltTestRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"


### PR DESCRIPTION
#### What is this PR doing?
Bumpt to `1.2.1`

#### How should this be manually tested?


#### What are the relevant tickets?

[VIDSOL-1003](https://jira.vonage.com/browse/VIDSOL-1003)

#### Checklist
- [x] Branch is based on `develop` (not `main`).
- [ ] Resolves a `Known Issue`.
- [ ] If yes, did you remove the item from the `docs/KNOWN_ISSUES.md`?
- [ ] Resolves an item reported in `Issues`.

#### Justification for skipping ci, if applied?
