### PR TITLE
VIDSOL-885: fix(video-core) reapply video effect on camera re-enable

### DIFF
--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PreviewPublisherState.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PreviewPublisherState.kt
@@ -64,6 +64,7 @@ data class PreviewPublisherState(
     override fun toggleVideo() {
         vonagePublisher.publishVideo = vonagePublisher.publishVideo.toggle()
         _isCameraEnabled.update { vonagePublisher.publishVideo }
+        if (vonagePublisher.publishVideo) applyVideoEffect(_videoEffect.value)
     }
 
     override fun toggleAudio() {

--- a/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PublisherState.kt
+++ b/vonage-video-core/src/main/java/com/vonage/android/kotlin/model/PublisherState.kt
@@ -123,6 +123,7 @@ data class PublisherState(
         userIntendedVideoOn = !userIntendedVideoOn
         vonagePublisher.publishVideo = userIntendedVideoOn
         _isCameraEnabled.update { userIntendedVideoOn }
+        if (userIntendedVideoOn) applyVideoEffect(_videoEffect.value)
     }
 
     override fun toggleAudio() {

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/model/PreviewPublisherStateTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/model/PreviewPublisherStateTest.kt
@@ -1,0 +1,87 @@
+package com.vonage.android.kotlin.model
+
+import android.view.View
+import com.vonage.android.kotlin.sdk.VonageBlurLevel
+import com.vonage.android.kotlin.sdk.VonagePublisher
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [PreviewPublisherState.toggleVideo].
+ *
+ * Key invariant: toggling the camera back ON must reapply the active [VideoEffect]
+ * to the SDK, because the OpenTok capture pipeline clears transformers on restart.
+ */
+class PreviewPublisherStateTest {
+
+    private var publishVideoState: Boolean = true
+
+    private lateinit var mockPublisher: VonagePublisher
+    private lateinit var previewPublisherState: PreviewPublisherState
+
+    @Before
+    fun setUp() {
+        publishVideoState = true
+        mockPublisher = mockk(relaxed = true) {
+            every { publishVideo } answers { publishVideoState }
+            every { publishVideo = any() } answers { publishVideoState = firstArg() }
+            every { view } returns mockk<View>(relaxed = true)
+        }
+        previewPublisherState = PreviewPublisherState(vonagePublisher = mockPublisher)
+    }
+
+    @Test
+    fun `toggleVideo turns camera off then back on`() {
+        assertTrue(publishVideoState)
+
+        previewPublisherState.toggleVideo()
+        assertFalse(publishVideoState)
+
+        previewPublisherState.toggleVideo()
+        assertTrue(publishVideoState)
+    }
+
+    @Test
+    fun `toggleVideo reapplies background image effect when camera is turned back on`() {
+        val effect = VideoEffect.BackgroundImage(id = "bg1", imagePath = "/path/to/image.jpg")
+        previewPublisherState.applyVideoEffect(effect)
+
+        previewPublisherState.toggleVideo() // off
+        previewPublisherState.toggleVideo() // on
+
+        verify(exactly = 2) { mockPublisher.applyBackgroundImage("/path/to/image.jpg") }
+    }
+
+    @Test
+    fun `toggleVideo does not reapply effect when camera is turned off`() {
+        val effect = VideoEffect.BackgroundImage(id = "bg1", imagePath = "/path/to/image.jpg")
+        previewPublisherState.applyVideoEffect(effect)
+
+        previewPublisherState.toggleVideo() // off only
+
+        verify(exactly = 1) { mockPublisher.applyBackgroundImage("/path/to/image.jpg") }
+    }
+
+    @Test
+    fun `toggleVideo reapplies blur effect when camera is turned back on`() {
+        previewPublisherState.applyVideoEffect(VideoEffect.BlurHigh)
+
+        previewPublisherState.toggleVideo() // off
+        previewPublisherState.toggleVideo() // on
+
+        verify(exactly = 2) { mockPublisher.applyBlur(VonageBlurLevel.HIGH) }
+    }
+
+    @Test
+    fun `toggleVideo with no effect does not call unnecessary SDK methods on re-enable`() {
+        previewPublisherState.toggleVideo() // off
+        previewPublisherState.toggleVideo() // on
+
+        verify(exactly = 1) { mockPublisher.applyBlur(VonageBlurLevel.NONE) }
+    }
+}

--- a/vonage-video-core/src/test/java/com/vonage/android/kotlin/model/PublisherStateTest.kt
+++ b/vonage-video-core/src/test/java/com/vonage/android/kotlin/model/PublisherStateTest.kt
@@ -1,8 +1,10 @@
 package com.vonage.android.kotlin.model
 
+import com.vonage.android.kotlin.sdk.VonageBlurLevel
 import com.vonage.android.kotlin.sdk.VonagePublisher
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -119,6 +121,58 @@ class PublisherStateTest {
         // User turns camera back on
         publisherState.toggleVideo()
         assertTrue(publishVideoState)
+    }
+
+    // endregion
+
+    // region toggleVideo — effect reapplication
+
+    @Test
+    fun `toggleVideo reapplies background image effect when camera is turned back on`() {
+        val effect = VideoEffect.BackgroundImage(id = "bg1", imagePath = "/path/to/image.jpg")
+        publisherState.applyVideoEffect(effect)
+
+        // Turn off
+        publisherState.toggleVideo()
+        assertFalse(publishVideoState)
+
+        // Turn back on — SDK must receive applyBackgroundImage again
+        publisherState.toggleVideo()
+        assertTrue(publishVideoState)
+
+        verify(exactly = 2) { mockPublisher.applyBackgroundImage("/path/to/image.jpg") }
+    }
+
+    @Test
+    fun `toggleVideo does not reapply effect when camera is turned off`() {
+        val effect = VideoEffect.BackgroundImage(id = "bg1", imagePath = "/path/to/image.jpg")
+        publisherState.applyVideoEffect(effect)
+
+        // Turn off — no additional applyBackgroundImage call expected
+        publisherState.toggleVideo()
+        assertFalse(publishVideoState)
+
+        verify(exactly = 1) { mockPublisher.applyBackgroundImage("/path/to/image.jpg") }
+    }
+
+    @Test
+    fun `toggleVideo reapplies blur effect when camera is turned back on`() {
+        publisherState.applyVideoEffect(VideoEffect.BlurHigh)
+
+        publisherState.toggleVideo() // off
+        publisherState.toggleVideo() // on
+
+        // Called once on applyVideoEffect, once on re-enable
+        verify(exactly = 2) { mockPublisher.applyBlur(VonageBlurLevel.HIGH) }
+    }
+
+    @Test
+    fun `toggleVideo with no effect does not call unnecessary SDK methods on re-enable`() {
+        // Default effect is None — re-enabling should call applyBlur(NONE) once
+        publisherState.toggleVideo() // off
+        publisherState.toggleVideo() // on
+
+        verify(exactly = 1) { mockPublisher.applyBlur(VonageBlurLevel.NONE) }
     }
 
     // endregion


### PR DESCRIPTION
## Summary

When a background image (or blur) was active and the user toggled the camera OFF then ON in the waiting room, the video effect was lost. The OpenTok SDK clears its video transformer pipeline when `publishVideo` is toggled back to `true`, but nothing reapplied the effect afterwards.

## Changes

- `PreviewPublisherState.toggleVideo()` — call `applyVideoEffect(_videoEffect.value)` after re-enabling the camera
- `PublisherState.toggleVideo()` — same fix for the in-call publisher

The existing `applyVideoEffect()` method already handles all `VideoEffect` variants (including `None`), so calling it on re-enable is safe and idempotent.

## Tests

- Added 4 tests to `PublisherStateTest` covering background image, blur, and `None` effect reapplication on camera toggle
- Added `PreviewPublisherStateTest` (new file) with the same 4 tests for the preview publisher

## Verification

- `./gradlew :vonage-video-core:test` — all tests pass
- `./gradlew detekt` — no violations