### PR TITLE
VIDSOL-1147: fix(feature-modules) align disabled flavor provider signatures with enabled

### DIFF
--- a/vonage-feature-archiving/build.gradle.kts
+++ b/vonage-feature-archiving/build.gradle.kts
@@ -47,7 +47,9 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.ui.tooling.preview)
 
-    enabledImplementation(libs.retrofit)
+    // retrofit is shared so the disabled flavor exposes the same provider signature
+    // (provideVonageArchiving(retrofit)) as enabled; the disabled stub ignores the arg.
+    implementation(libs.retrofit)
     enabledImplementation(libs.okhttp)
 
     testImplementation(libs.junit.junit)

--- a/vonage-feature-archiving/src/disabled/java/com/vonage/android/archiving/di/ArchivingModule.kt
+++ b/vonage-feature-archiving/src/disabled/java/com/vonage/android/archiving/di/ArchivingModule.kt
@@ -2,9 +2,10 @@ package com.vonage.android.archiving.di
 
 import com.vonage.android.archiving.DisabledVonageArchiving
 import com.vonage.android.archiving.VonageArchiving
+import retrofit2.Retrofit
 
 object ArchivingModule {
 
-    fun provideVonageArchiving(): VonageArchiving =
+    fun provideVonageArchiving(@Suppress("UNUSED_PARAMETER") retrofit: Retrofit): VonageArchiving =
         DisabledVonageArchiving()
 }

--- a/vonage-feature-captions/build.gradle.kts
+++ b/vonage-feature-captions/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.opentok.android.sdk)
 
-    enabledImplementation(libs.retrofit)
+    // retrofit is shared so the disabled flavor exposes the same provider signature
+    // (provideVonageCaptions(retrofit)) as enabled; the disabled stub ignores the arg.
+    implementation(libs.retrofit)
     enabledImplementation(libs.okhttp)
 
     testImplementation(libs.junit.junit)

--- a/vonage-feature-captions/src/disabled/java/com/vonage/android/captions/di/CaptionsModule.kt
+++ b/vonage-feature-captions/src/disabled/java/com/vonage/android/captions/di/CaptionsModule.kt
@@ -2,9 +2,11 @@ package com.vonage.android.captions.di
 
 import com.vonage.android.captions.DisabledVonageCaptions
 import com.vonage.android.captions.VonageCaptions
+import retrofit2.Retrofit
 
 object CaptionsModule {
 
-    fun provideVonageCaptions(): VonageCaptions = DisabledVonageCaptions()
+    fun provideVonageCaptions(@Suppress("UNUSED_PARAMETER") retrofit: Retrofit): VonageCaptions =
+        DisabledVonageCaptions()
 
 }

--- a/vonage-feature-screensharing/src/disabled/java/com/vonage/android/screensharing/di/ScreenSharingModule.kt
+++ b/vonage-feature-screensharing/src/disabled/java/com/vonage/android/screensharing/di/ScreenSharingModule.kt
@@ -2,10 +2,11 @@ package com.vonage.android.screensharing.di
 
 import com.vonage.android.screensharing.DisabledScreenSharing
 import com.vonage.android.screensharing.VonageScreenSharing
+import android.content.Context
 
 object ScreenSharingModule {
 
-    fun provideVonageScreenSharing(): VonageScreenSharing =
+    fun provideVonageScreenSharing(@Suppress("UNUSED_PARAMETER") context: Context): VonageScreenSharing =
         DisabledScreenSharing()
 
 }

--- a/vonage-feature-settings/src/disabled/java/com/vonage/android/settings/ui/SettingsScreen.kt
+++ b/vonage-feature-settings/src/disabled/java/com/vonage/android/settings/ui/SettingsScreen.kt
@@ -9,8 +9,8 @@ import com.vonage.android.settings.SettingsUiState
 @Composable
 fun SettingsScreen(
     uiState: SettingsUiState,
+    actions: SettingsScreenActions,
     modifier: Modifier = Modifier,
-    actions: SettingsScreenActions = SettingsScreenActions(),
 ) {
 
 }

--- a/vonage-meeting-room/src/archivingDisabled/java/com/vonage/android/meetingroom/internal/factory/ArchivingFactory.kt
+++ b/vonage-meeting-room/src/archivingDisabled/java/com/vonage/android/meetingroom/internal/factory/ArchivingFactory.kt
@@ -6,4 +6,4 @@ import retrofit2.Retrofit
 
 @Suppress("UNUSED_PARAMETER")
 internal fun createVonageArchiving(retrofit: Retrofit): VonageArchiving =
-    ArchivingModule.provideVonageArchiving()
+    ArchivingModule.provideVonageArchiving(retrofit)

--- a/vonage-meeting-room/src/captionsDisabled/java/com/vonage/android/meetingroom/internal/factory/CaptionsFactory.kt
+++ b/vonage-meeting-room/src/captionsDisabled/java/com/vonage/android/meetingroom/internal/factory/CaptionsFactory.kt
@@ -6,4 +6,4 @@ import retrofit2.Retrofit
 
 @Suppress("UNUSED_PARAMETER")
 internal fun createVonageCaptions(retrofit: Retrofit): VonageCaptions =
-    CaptionsModule.provideVonageCaptions()
+    CaptionsModule.provideVonageCaptions(retrofit)

--- a/vonage-meeting-room/src/screensharingDisabled/java/com/vonage/android/meetingroom/internal/factory/ScreenSharingFactory.kt
+++ b/vonage-meeting-room/src/screensharingDisabled/java/com/vonage/android/meetingroom/internal/factory/ScreenSharingFactory.kt
@@ -6,4 +6,4 @@ import com.vonage.android.screensharing.di.ScreenSharingModule
 
 @Suppress("UNUSED_PARAMETER")
 internal fun createVonageScreenSharing(context: Context): VonageScreenSharing =
-    ScreenSharingModule.provideVonageScreenSharing()
+    ScreenSharingModule.provideVonageScreenSharing(context)


### PR DESCRIPTION
## Summary

Fixes signature mismatches between `enabled` and `disabled` flavor DI providers for archiving, captions, screensharing, and settings.

The `disabled` stubs now accept the same parameters as their `enabled` counterparts, removing the `@Suppress("UNUSED_PARAMETER")` workaround in the factory layer and making flavor-swapping compile-safe.

## Changes

- `vonage-feature-archiving`: move `retrofit` to `implementation` so the disabled flavor can reference it; align `ArchivingModule.provideVonageArchiving` signature
- `vonage-feature-captions`: same pattern for captions
- `vonage-feature-screensharing`: align `ScreenSharingModule.provideVonageScreenSharing` to accept `Context`
- `vonage-feature-settings`: make `actions` a required parameter in disabled `SettingsScreen` to match enabled
- `vonage-meeting-room` (archivingDisabled, captionsDisabled, screensharingDisabled factories): pass through the parameter instead of suppressing it

## Testing

- [ ] Builds with disabled flavors compile without errors
- [ ] Builds with enabled flavors unaffected